### PR TITLE
Improve difficulty determining for Catch and Mania

### DIFF
--- a/src/Checks/Standard/Spread/CheckCloseOverlap.cs
+++ b/src/Checks/Standard/Spread/CheckCloseOverlap.cs
@@ -68,11 +68,11 @@ namespace MapsetVerifier.Checks.Standard.Spread
             foreach (var beatmap in beatmapSet.Beatmaps)
             {
                 // Beatmaps are sorted by interpreted difficulty.
-                if (beatmap.GetDifficulty(true) > skipAfterDifficulty)
+                if (beatmap.GetDifficulty() > skipAfterDifficulty)
                     break;
 
                 // This check only applies to easy/lowest diff normals, so if we find an easy, normals cannot not be lowest diff.
-                if (beatmap.GetDifficulty(true) == Beatmap.Difficulty.Easy)
+                if (beatmap.GetDifficulty() == Beatmap.Difficulty.Easy)
                     skipAfterDifficulty = Beatmap.Difficulty.Easy;
 
                 foreach (var hitObject in beatmap.HitObjects)

--- a/src/Parser/Objects/Beatmap.cs
+++ b/src/Parser/Objects/Beatmap.cs
@@ -590,6 +590,19 @@ namespace MapsetVerifier.Parser.Objects
         /// </summary>
         public Difficulty GetDifficulty()
         {
+            var difficultyFromName = GetDifficultyFromName();
+            if (difficultyFromName == null && GeneralSettings.mode is Mode.Catch or Mode.Mania)
+            {
+                // Assume custom diff names are always experts for modes we can't calculate star rating for
+                return Difficulty.Expert;
+            }
+
+            if (difficultyFromName != null)
+            {
+                return (Difficulty) difficultyFromName;
+            }
+            
+            // We can't determine the difficulty by name so instead use star rating
             Difficulty difficulty;
 
             if (StarRating < 2.0f) difficulty = Difficulty.Easy;
@@ -599,7 +612,7 @@ namespace MapsetVerifier.Parser.Objects
             else if (StarRating < 6.5f) difficulty = Difficulty.Expert;
             else difficulty = Difficulty.Ultra;
 
-            return GetDifficultyFromName() ?? difficulty;
+            return difficulty;
         }
 
         public Difficulty? GetDifficultyFromName()

--- a/src/Parser/Objects/Beatmap.cs
+++ b/src/Parser/Objects/Beatmap.cs
@@ -588,7 +588,7 @@ namespace MapsetVerifier.Parser.Objects
         ///     Returns the interpreted difficulty level based on the star rating of the beatmap
         ///     (may be inaccurate since recent sr reworks were done), can optionally consider diff names.
         /// </summary>
-        public Difficulty GetDifficulty(bool considerName = false)
+        public Difficulty GetDifficulty()
         {
             Difficulty difficulty;
 
@@ -598,9 +598,6 @@ namespace MapsetVerifier.Parser.Objects
             else if (StarRating < 5.3f) difficulty = Difficulty.Insane;
             else if (StarRating < 6.5f) difficulty = Difficulty.Expert;
             else difficulty = Difficulty.Ultra;
-
-            if (!considerName)
-                return difficulty;
 
             return GetDifficultyFromName() ?? difficulty;
         }

--- a/src/Parser/Objects/BeatmapSet.cs
+++ b/src/Parser/Objects/BeatmapSet.cs
@@ -34,7 +34,7 @@ namespace MapsetVerifier.Parser.Objects
             HitSoundFiles = GetUsedHitSoundFiles().ToList();
             hsTrack.Complete();
 
-            Beatmaps = Beatmaps.OrderBy(beatmap => beatmap.GeneralSettings.mode).ThenBy(beatmap => beatmap.GetDifficulty(true)).ThenBy(beatmap => beatmap.StarRating).ThenBy(beatmap => beatmap.GetObjectDensity()).ToList();
+            Beatmaps = Beatmaps.OrderBy(beatmap => beatmap.GeneralSettings.mode).ThenBy(beatmap => beatmap.GetDifficulty()).ThenBy(beatmap => beatmap.StarRating).ThenBy(beatmap => beatmap.GetObjectDensity()).ToList();
 
             mapsetTrack.Complete();
         }

--- a/src/Rendering/ChecksRenderer.cs
+++ b/src/Rendering/ChecksRenderer.cs
@@ -53,7 +53,7 @@ namespace MapsetVerifier.Rendering
                         var version = Encode(beatmap.MetadataSettings.version);
 
                         return DivAttr("card-difficulty", DataAttr("difficulty", version),
-                            RenderBeatmapInterpretation(beatmap, beatmap.GetDifficulty(true)),
+                            RenderBeatmapInterpretation(beatmap, beatmap.GetDifficulty()),
                             RenderBeatmapCategories(beatmapIssues, version));
                     }))) +
                 Div("paste-separator select-separator") +

--- a/src/Rendering/SkillChartRenderer.cs
+++ b/src/Rendering/SkillChartRenderer.cs
@@ -144,7 +144,7 @@ namespace MapsetVerifier.Rendering
 
         private static Beatmap.Difficulty DifficultyOf(Beatmap map)
         {
-            var diff = map.GetDifficulty(true);
+            var diff = map.GetDifficulty();
 
             // Ultra uses a completely black color, which blends into the background too much, hence treat like Expert instead.
             return diff == Beatmap.Difficulty.Ultra ? Beatmap.Difficulty.Expert : diff;


### PR DESCRIPTION
I saw some SR calculation things for taiko, so I assumed we don't need this behaviour for that mode. But it might be good to check that, as I wasn't sure.