### PR TITLE
Remove no longer applicable check for `.osu` files exceeding 1 MB in file size

### DIFF
--- a/src/Checks/AllModes/General/Files/CheckUpdateValidity.cs
+++ b/src/Checks/AllModes/General/Files/CheckUpdateValidity.cs
@@ -57,11 +57,6 @@ namespace MapsetVerifier.Checks.AllModes.General.Files
             new()
             {
                 {
-                    "File Size",
-                    new IssueTemplate(Issue.Level.Problem, "\"{0}\" will cut any update at the 1 MB mark ({1} MB), causing objects to disappear.", "path", "file size").WithCause("A .osu file exceeds 1 MB in file size.")
-                },
-
-                {
                     "Wrong Format",
                     new IssueTemplate(Issue.Level.Warning, "\"{0}\" should be named \"{1}\" to receive updates.", "file name", "artist - title (creator) [version].osu").WithCause("A .osu file is not named after the mentioned format using its respective properties.")
                 },
@@ -89,13 +84,6 @@ namespace MapsetVerifier.Checks.AllModes.General.Files
 
                 if (beatmap.GetOsuFileName().ToLower() != fileName.ToLower())
                     yield return new Issue(GetTemplate("Wrong Format"), null, fileName, beatmap.GetOsuFileName());
-
-                // Updating .osu files larger than 1 mb will cause the update to stop at the 1 mb mark
-                var fileInfo = new FileInfo(songFilePath);
-                var mb = fileInfo.Length / Math.Pow(1024, 2);
-
-                if (mb > 1)
-                    yield return new Issue(GetTemplate("File Size"), null, filePath, $"{mb:0.##}");
             }
         }
     }


### PR DESCRIPTION
Yesterday I was contacted by BN [Quenlla](https://osu.ppy.sh/users/4725379) regarding a [beatmap that they are working on](https://osu.ppy.sh/beatmapsets/2378534/discussion/-/generalAll/total). The `.osu` file of that marathon naturally exceeds 1 MB, which trips a MapsetVerifier check. While Quenlla's question was more regarding a workaround that they applied to the beatmap in question to circumvent this check, I found it dubious to begin with, for the following reasons:

- There is no such explicit limitation imposed on `.osu` files in `osu-web-10` source.

- Quenlla claims to be unable to reproduce the "beatmap getting cut after 1 MB" issue.

- I tried myself and also have not been able to reproduce this issue.

- There is no concrete evidence that I can find for this claim in communities I have access to. The earliest I saw it mentioned was in a [BN server conversation in November 2018](https://discord.com/channels/316154420591067136/316154420591067136/511657544415182858). After that point, all I see are mostly rehashes of the claim with no substantiation.

- There are several existing beatmaps with `.osu` file sizes exceeding 1 MB: 
![image](https://github.com/user-attachments/assets/fe349278-fa99-44e1-a7c4-6d32394c5403)

- There are no `osu-stable-issues` reports for this issue.

- From internal discussions, I have it on @peppy's authority that "there was definitely a time this was the case, due to either php or asp.net post limitations. but it was fixed years ago".

Due to the aforementioned overwhelming evidence I think it is best to remove the check to avoid similar situations going forward.

---

Disclaimer: I have not tested this, because I can't run the frontend on my dev machine due to electron being pinned to a version that doesn't have apple silicon builds, and there are no unit tests. Buyer beware.