### PR TITLE
Fix taiko SR on the Overview tab

### DIFF
--- a/MapsetVerifier.Rendering/SkillChartRenderer.cs
+++ b/MapsetVerifier.Rendering/SkillChartRenderer.cs
@@ -116,9 +116,7 @@ namespace MapsetVerifier.Rendering
                         accumulatedPeaks[index] = [(float)strainPeaks[index]];
             }
 
-            return GetPeakSeries(beatmap, accumulatedPeaks, peak =>
-                // TODO: Is this the same for t/c/m?
-                peak.Value.Sum() + Math.Abs(peak.Value[0] - peak.Value[1]) * 2, chart);
+            return GetPeakSeries(beatmap, accumulatedPeaks, GetSkillValueToStarRatingFunc(beatmap.GeneralSettings.mode), chart);
         }
 
         private static Series GetPeakSeries<T>(Beatmap beatmap, IEnumerable<T> data, Func<T, float> Value, LineChart chart)
@@ -198,6 +196,16 @@ namespace MapsetVerifier.Rendering
             }
 
             return Color.FromArgb((int)red, (int)green, (int)blue);
+        }
+        
+        private static Func<KeyValuePair<int, List<float>>, float> GetSkillValueToStarRatingFunc(Beatmap.Mode mode)
+        {
+            return mode switch
+            {
+                Beatmap.Mode.Standard => peak => peak.Value.Sum() + Math.Abs(peak.Value[0] - peak.Value[1]) * 2,
+                Beatmap.Mode.Taiko => peak => (float)(10.43 * Math.Log((peak.Value[0] * 1.4) / 8 + 1)),
+                _ => peak => peak.Value.Sum()   // TODO: Implement transformation functions for Mania and Catch
+            };
         }
     }
 }


### PR DESCRIPTION
Taiko SR and Skill Graphs currently cause the Overview tab to throw an IndexOutOfBounds exception - because it is running this rescaling code which is only intended for osu! (Standard) SR calc:

`peak.Value.Sum() + Math.Abs(peak.Value[0] - peak.Value[1]) * 2, chart);`

Index out-of-bounds due to `peak.Value[1]` being referenced when Taiko consolidates everything into one Strain Skill.

Rather, it should be using this, which is taken from [here](https://github.com/ppy/osu/blob/645d27bb3245e6324e203412963940b584eee34c/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs#L244):
`(float)(10.43 * Math.Log((peak.Value[0] * 1.4) / 8 + 1))`

For Mania and Catch, I've just changed those to leave it unscaled and added a TODO note. Since skills aren't implemented there, it should result in 0* SR anyway.