### PR TITLE
Fix Concurrent Objects checks

### DIFF
--- a/MapsetVerifier.Checks/AllModes/Compose/CheckConcurrent.cs
+++ b/MapsetVerifier.Checks/AllModes/Compose/CheckConcurrent.cs
@@ -52,12 +52,14 @@ namespace MapsetVerifier.Checks.AllModes.Compose
             {
                 {
                     "Concurrent Objects",
-                    new IssueTemplate(Issue.Level.Problem, "{0} Concurrent {1}.", "timestamp - ", "hit objects").WithCause("A hit object starts before another hit object has ended. For mania this also " + "requires that the objects are in the same column.")
+                    new IssueTemplate(Issue.Level.Problem, "{0} Concurrent {1}.", "timestamp - ", "hit objects")
+                        .WithCause("A hit object starts before another hit object has ended. For mania this also requires that the objects are in the same column.")
                 },
 
                 {
                     "Almost Concurrent Objects",
-                    new IssueTemplate(Issue.Level.Problem, "{0} Within {1} ms of one another.", "timestamp - ", "gap").WithCause("Two hit objects are less than 10 ms apart from one another. For mania this also " + "requires that the objects are in the same column.")
+                    new IssueTemplate(Issue.Level.Problem, "{0} {1} Within {2} ms of one another.", "timestamp - ", "other timestamp - ", "gap")
+                        .WithCause("Two hit objects are less than 10 ms apart from one another. For mania this also requires that the objects are in the same column.")
                 }
             };
 


### PR DESCRIPTION
Right now, the `CheckConcurrent` check errors out whenever it is triggered, since [the Issue Template only expects a single timestamp argument](https://github.com/Naxesss/MapsetVerifier/blob/14f123425217042af385979b9e04b27e4eaf4c0c/MapsetVerifier.Checks/AllModes/Compose/CheckConcurrent.cs#L55), but we are passing two timestamps when calling it.

This happens for both the actual concurrent objects issue, and the almost concurrent objects issue.

This PR fixes it:
* For actual concurrent: I opted to change how it's called instead of changing the template itself, since I think that makes more sense. Any instance of concurrent objects will just be the same timestamp for both objects by definition - so doesn't make sense to list that timestamp twice.
* For almost concurrent: I changed the template to allow for both timestamps instead, since those timestamps would actually be different from each other

# Screenshots

Concurrent:
<img width="1172" height="700" alt="image" src="https://github.com/user-attachments/assets/d7dedb78-b4b3-4f19-846a-2ac784a6285c" />

Almost Concurrent:
<img width="1172" height="700" alt="image" src="https://github.com/user-attachments/assets/3cbd97b2-1635-451b-9d92-0306fc93a70c" />
