### PR TITLE
Add functionality for exporting checks metadata

### DIFF
--- a/.github/workflows/export-checks-metadata.yaml
+++ b/.github/workflows/export-checks-metadata.yaml
@@ -1,0 +1,37 @@
+name: Export Checks Metadata
+
+on:
+#    push:
+#        branches: [main]
+    workflow_dispatch:
+
+jobs:
+    export:
+        runs-on: windows-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: "9.x"
+
+            - name: Build exporter
+              run: dotnet build MapsetVerifier.Exports -c Release --no-incremental
+
+            - name: Export checks metadata to JSON
+              run: |
+                  New-Item -ItemType Directory -Force -Path scripts
+                  dotnet run --project MapsetVerifier.Exports -c Release --no-build -- scripts/checks-metadata.json
+                  if (Test-Path scripts/checks-metadata.json) {
+                    Write-Host "Exported checks metadata successfully."
+                  }
+
+            - name: Upload checks-metadata.json
+              uses: actions/upload-artifact@v4
+              with:
+                  name: checks-metadata
+                  path: scripts/checks-metadata.json
+
+## TODO: make use of the json artifact somewhere for the website, and enable trigger on push to main probably

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ dist
 *.userosscache
 *.sln.docstates
 
+# Generated checks metadata (regenerate with scripts/export-checks-metadata.*)
+scripts/checks-metadata.json
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/MapsetVerifier.Exports/MapsetVerifier.Exports.csproj
+++ b/MapsetVerifier.Exports/MapsetVerifier.Exports.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>MapsetVerifier.Exports</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MapsetVerifier.Checks\MapsetVerifier.Checks.csproj" />
+    <ProjectReference Include="..\MapsetVerifier.Framework\MapsetVerifier.Framework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MapsetVerifier.Exports/Program.cs
+++ b/MapsetVerifier.Exports/Program.cs
@@ -1,0 +1,139 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MapsetVerifier.Framework;
+using MapsetVerifier.Framework.Objects;
+using MapsetVerifier.Framework.Objects.Metadata;
+using MapsetVerifier.Parser.Objects;
+
+namespace MapsetVerifier.Exports;
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+
+        try
+        {
+            Checker.SuppressLoadLogging = true;
+            Checker.LoadDefaultChecks();
+
+            var checks = CheckerRegistry.GetChecks();
+            var items = checks.Select(SerializeCheck).ToList();
+
+            var root = new
+            {
+                generatedAt = DateTime.UtcNow.ToString("o"),
+                version = GetVersion(),
+                checks = items,
+            };
+
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+            };
+
+            var json = JsonSerializer.Serialize(root, options);
+            var outputPath =
+                args.Length > 0 && !string.IsNullOrWhiteSpace(args[0])
+                    ? args[0]
+                    : Path.Combine(FindRepoRoot(), "scripts", "checks-metadata.json");
+
+            var dir = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            File.WriteAllText(outputPath, json);
+            Console.Error.WriteLine($"Written {items.Count} checks to {outputPath}");
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    /// <summary>Finds the repository root by walking up until MapsetVerifier.sln or .git is found.</summary>
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        if (string.IsNullOrEmpty(dir))
+            dir = Directory.GetCurrentDirectory();
+
+        for (var d = new DirectoryInfo(dir); d != null; d = d.Parent)
+        {
+            if (File.Exists(Path.Combine(d.FullName, "MapsetVerifier.sln")) ||
+                Directory.Exists(Path.Combine(d.FullName, ".git")))
+                return d.FullName;
+        }
+
+        return Directory.GetCurrentDirectory();
+    }
+
+    private static string GetVersion()
+    {
+        try
+        {
+            var asm = Assembly.GetEntryAssembly();
+            return asm?.GetName().Version?.ToString() ?? "0.0.0";
+        }
+        catch
+        {
+            return "0.0.0";
+        }
+    }
+
+    private static object SerializeCheck(Check check)
+    {
+        var meta = check.GetMetadata();
+        var checkType = check switch
+        {
+            BeatmapCheck => "Beatmap",
+            BeatmapSetCheck => "BeatmapSet",
+            GeneralCheck => "General",
+            _ => "Unknown",
+        };
+
+        var item = new Dictionary<string, object?>
+        {
+            ["name"] = check.GetType().Name,
+            ["fullName"] = check.GetType().FullName,
+            ["checkType"] = checkType,
+            ["category"] = meta.Category,
+            ["message"] = meta.Message,
+            ["author"] = meta.Author,
+            ["applicableModes"] = meta.GetMode(),
+            ["documentation"] = meta.Documentation,
+            ["templates"] = check
+                .GetTemplates()
+                .ToDictionary(
+                    kv => kv.Key,
+                    kv => new
+                    {
+                        level = kv.Value.Level.ToString(),
+                        formatString = kv.Value.FormatString,
+                        defaultArguments = kv
+                            .Value.GetDefaultArguments()
+                            .Select(a => a?.ToString())
+                            .ToArray(),
+                        cause = kv.Value.Cause,
+                    }
+                ),
+        };
+
+        if (meta is BeatmapCheckMetadata bmMeta)
+        {
+            item["modes"] = bmMeta.Modes.Select(m => m.ToString()).ToArray();
+            item["difficulties"] = bmMeta.Difficulties.Select(d => d.ToString()).ToArray();
+        }
+
+        return item;
+    }
+}

--- a/MapsetVerifier.Framework/Checker.cs
+++ b/MapsetVerifier.Framework/Checker.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Reflection;
 using MapsetVerifier.Framework.Objects;
 using MapsetVerifier.Framework.Objects.Attributes;
@@ -217,14 +217,18 @@ namespace MapsetVerifier.Framework
             }
         }
 
+        /// <summary> When true, LoadCheckAssembly does not write to the console (e.g. when exporting metadata). </summary>
+        public static bool SuppressLoadLogging { get; set; }
+
         /// <summary> Adds checks from the given assembly to the CheckerRegistry. </summary>
         private static void LoadCheckAssembly(Assembly assembly)
         {
             foreach (var type in assembly.GetExportedTypes())
             {
                 var attr = type.CustomAttributes.FirstOrDefault(attr => attr.AttributeType.Name == nameof(CheckAttribute));
-                Log.Debug("Checking exported type {TypeFullName}", type.FullName);
-                
+                if (!SuppressLoadLogging)
+                    Log.Debug("Checking exported type {TypeFullName}", type.FullName);
+
                 if (attr == null)
                     continue;
 

--- a/MapsetVerifier.Framework/Objects/IssueTemplate.cs
+++ b/MapsetVerifier.Framework/Objects/IssueTemplate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -39,6 +39,9 @@ namespace MapsetVerifier.Framework.Objects
         }
 
         public Issue.Level Level { get; }
+
+        /// <summary> The format string with {0}, {1}, etc. placeholders. </summary>
+        public string FormatString => format;
 
         /// <summary> Returns the template with a given cause, which will be shown below the issue template in the documentation. </summary>
         public IssueTemplate WithCause(string cause)

--- a/MapsetVerifier.sln
+++ b/MapsetVerifier.sln
@@ -1,4 +1,4 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsetVerifier", "src\MapsetVerifier.csproj", "{2AE6F8E7-1D59-481D-A4E8-6D0145CB22A4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsetVerifier.Framework", "MapsetVerifier.Framework\MapsetVerifier.Framework.csproj", "{E9EC73E5-C508-463B-957B-484601EAEBC5}"
@@ -16,6 +16,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsetVerifier.Parser.Tests", "MapsetVerifier.Parser.Tests\MapsetVerifier.Parser.Tests.csproj", "{D9E4F0A3-7C2C-4A8C-9E6A-0F4E6F9D1234}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsetVerifier.Logging", "MapsetVerifier.Logging\MapsetVerifier.Logging.csproj", "{0886BE26-F4C3-4919-968D-7D569DF5B1B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapsetVerifier.Exports", "MapsetVerifier.Exports\MapsetVerifier.Exports.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,5 +61,9 @@ Global
 		{0886BE26-F4C3-4919-968D-7D569DF5B1B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0886BE26-F4C3-4919-968D-7D569DF5B1B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0886BE26-F4C3-4919-968D-7D569DF5B1B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/scripts/export-checks-metadata.ps1
+++ b/scripts/export-checks-metadata.ps1
@@ -1,0 +1,23 @@
+# Export all beatmap check metadata to JSON.
+# Run from repository root: .\scripts\export-checks-metadata.ps1 [output-path]
+# If output-path is omitted, writes to scripts/checks-metadata.json.
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+if (-not (Test-Path (Join-Path $RepoRoot "MapsetVerifier.sln"))) {
+    $RepoRoot = Get-Location
+}
+
+$outPath = $args[0]
+if (-not $outPath) { $outPath = "scripts/checks-metadata.json" }
+$projectPath = Join-Path $RepoRoot "MapsetVerifier.Exports\MapsetVerifier.Exports.csproj"
+
+Push-Location $RepoRoot
+try {
+    dotnet build $projectPath -c Release --verbosity quiet
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    dotnet run --project $projectPath -c Release --no-build -- $outPath
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/scripts/export-checks-metadata.sh
+++ b/scripts/export-checks-metadata.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Export all beatmap check metadata to JSON.
+# Run from repository root: ./scripts/export-checks-metadata.sh [output-path]
+# If output-path is omitted, writes to scripts/checks-metadata.json.
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_PATH="$REPO_ROOT/MapsetVerifier.Exports/MapsetVerifier.Exports.csproj"
+OUT_PATH="${1:-scripts/checks-metadata.json}"
+
+cd "$REPO_ROOT"
+dotnet build "$PROJECT_PATH" -c Release --verbosity quiet
+dotnet run --project "$PROJECT_PATH" -c Release --no-build -- "$OUT_PATH"


### PR DESCRIPTION
adds a console app, scripts, and github action for exporting all beatmap checks' metadata in a json file, for future use in automated website documentation.

will open another PR in the future that does something with the generated json rather than just upload it as an artifact. gotta figure out how I should fetch it from the website's end.

can be tested via either running the `MapsetVerifier.Exports` config or running `scripts/export-checks-metadata.ps1` / `scripts/export-checks-metadata.sh`