### PR TITLE
multiple UI adjustments

### DIFF
--- a/MapsetVerifier.Server/Model/BeatmapAnalysis/ObjectsOverviewResult.cs
+++ b/MapsetVerifier.Server/Model/BeatmapAnalysis/ObjectsOverviewResult.cs
@@ -38,6 +38,7 @@ public class ObjectsOverviewDifficulty
     public List<ObjectsTimelineObject> TimelineObjects { get; set; } = [];
     public List<ObjectsTimingSegment> TimingSegments { get; set; } = [];
     public List<ObjectsSnappingBucket> Snappings { get; set; } = [];
+    public List<double> UnsnappedEdgeTimesMs { get; set; } = [];
 }
 
 public class ObjectsBreakPeriod
@@ -79,4 +80,5 @@ public class ObjectsSnappingBucket
     public string Label { get; set; } = string.Empty;
     public int Count { get; set; }
     public double Percentage { get; set; }
+    public List<double> EdgeTimesMs { get; set; } = [];
 }

--- a/MapsetVerifier.Server/Service/BeatmapAnalysisService.cs
+++ b/MapsetVerifier.Server/Service/BeatmapAnalysisService.cs
@@ -435,8 +435,10 @@ public static class BeatmapAnalysisService
             .ToList();
 
         var snappingCounts = SupportedSnapDivisors.ToDictionary(divisor => divisor, _ => 0);
+        var snappingEdgeTimes = SupportedSnapDivisors.ToDictionary(divisor => divisor, _ => new List<double>());
         var edgeCount = 0;
         var unsnappedCount = 0;
+        var unsnappedEdgeTimes = new List<double>();
 
         foreach (var hitObject in beatmap.HitObjects)
         {
@@ -453,6 +455,7 @@ public static class BeatmapAnalysisService
                 if (unsnapIssue != null)
                 {
                     unsnappedCount++;
+                    unsnappedEdgeTimes.Add(edgeTime);
                     continue;
                 }
 
@@ -460,6 +463,7 @@ public static class BeatmapAnalysisService
                 if (snappingCounts.ContainsKey(divisor))
                 {
                     snappingCounts[divisor]++;
+                    snappingEdgeTimes[divisor].Add(edgeTime);
                 }
             }
         }
@@ -478,6 +482,7 @@ public static class BeatmapAnalysisService
             BreakPeriods = breakPeriods,
             TimelineObjects = timelineObjects,
             TimingSegments = timingSegments,
+            UnsnappedEdgeTimesMs = unsnappedEdgeTimes,
             Snappings = SupportedSnapDivisors
                 .Select(divisor => new ObjectsSnappingBucket
                 {
@@ -486,6 +491,7 @@ public static class BeatmapAnalysisService
                     Count = snappingCounts[divisor],
                     Percentage =
                         edgeCount > 0 ? snappingCounts[divisor] * 100d / totalSnapPoints : 0,
+                    EdgeTimesMs = snappingEdgeTimes[divisor],
                 })
                 .ToList(),
         };

--- a/MapsetVerifier.Server/Service/BeatmapAnalysisService.cs
+++ b/MapsetVerifier.Server/Service/BeatmapAnalysisService.cs
@@ -435,7 +435,10 @@ public static class BeatmapAnalysisService
             .ToList();
 
         var snappingCounts = SupportedSnapDivisors.ToDictionary(divisor => divisor, _ => 0);
-        var snappingEdgeTimes = SupportedSnapDivisors.ToDictionary(divisor => divisor, _ => new List<double>());
+        var snappingEdgeTimes = SupportedSnapDivisors.ToDictionary(
+            divisor => divisor,
+            _ => new List<double>()
+        );
         var edgeCount = 0;
         var unsnappedCount = 0;
         var unsnappedEdgeTimes = new List<double>();

--- a/electron-app/src/Types.ts
+++ b/electron-app/src/Types.ts
@@ -589,6 +589,8 @@ export type ObjectsOverviewDifficulty = {
   timelineObjects: ObjectsTimelineObject[];
   timingSegments: ObjectsTimingSegment[];
   snappings: ObjectsSnappingBucket[];
+  /** Populated by server analysis; omit if using an older API. */
+  unsnappedEdgeTimesMs?: number[];
 };
 
 export type ObjectsBreakPeriod = {
@@ -625,4 +627,6 @@ export type ObjectsSnappingBucket = {
   label: string;
   count: number;
   percentage: number;
+  /** Edge timestamps for this snap column; omit if using an older API. */
+  edgeTimesMs?: number[];
 };

--- a/electron-app/src/components/checks/DifficultyInfo.tsx
+++ b/electron-app/src/components/checks/DifficultyInfo.tsx
@@ -12,6 +12,23 @@ interface DifficultyInfoProps {
   currentOverrideResult?: ApiCategoryOverrideCheckResult;
 }
 
+const getDifficultyBadgeColor = (difficulty: string) => {
+  switch (difficulty) {
+    case 'Easy':
+      return 'blue';
+    case 'Normal':
+      return 'green';
+    case 'Hard':
+      return 'yellow';
+    case 'Insane':
+      return 'red';
+    case 'Expert':
+      return 'grape';
+    default:
+      return 'grape';
+  }
+};
+
 function DifficultyInfo({
   hoveredDifficulty,
   selectedCategory,
@@ -32,7 +49,13 @@ function DifficultyInfo({
         />
         <Text maw="60%">{hoveredDifficulty.category}</Text>
         {hoveredDifficulty.difficultyLevel && (
-          <Badge size="xs" color="grape" variant="light">
+          <Badge
+            size="xs"
+            color={getDifficultyBadgeColor(
+              currentOverrideResult?.categoryResult.difficultyLevel ?? hoveredDifficulty.difficultyLevel,
+            )}
+            variant="light"
+          >
             {currentOverrideResult ? (
               <DifficultyName
                 difficulty={currentOverrideResult.categoryResult.difficultyLevel}

--- a/electron-app/src/components/checks/DifficultyInfo.tsx
+++ b/electron-app/src/components/checks/DifficultyInfo.tsx
@@ -1,4 +1,4 @@
-﻿import { Badge, Flex, Text } from '@mantine/core';
+﻿import { Badge, Flex, Text, Tooltip } from '@mantine/core';
 import { ApiCategoryCheckResult, ApiCategoryOverrideCheckResult, Level } from '../../Types';
 import DifficultyName from '../common/DifficultyName';
 import StarRatingBadge from '../common/StarRatingBadge.tsx';
@@ -49,25 +49,27 @@ function DifficultyInfo({
         />
         <Text maw="60%">{hoveredDifficulty.category}</Text>
         {hoveredDifficulty.difficultyLevel && (
-          <Badge
-            size="xs"
-            color={getDifficultyBadgeColor(
-              currentOverrideResult?.categoryResult.difficultyLevel ?? hoveredDifficulty.difficultyLevel,
-            )}
-            variant="light"
-          >
-            {currentOverrideResult ? (
-              <DifficultyName
-                difficulty={currentOverrideResult.categoryResult.difficultyLevel}
-                mode={currentOverrideResult.categoryResult.mode}
-              />
-            ) : (
-              <DifficultyName
-                difficulty={hoveredDifficulty.difficultyLevel}
-                mode={hoveredDifficulty.mode}
-              />
-            )}
-          </Badge>
+          <Tooltip label="Interpreted difficulty level">
+            <Badge
+              size="xs"
+              color={getDifficultyBadgeColor(
+                currentOverrideResult?.categoryResult.difficultyLevel ?? hoveredDifficulty.difficultyLevel,
+              )}
+              variant="light"
+            >
+              {currentOverrideResult ? (
+                <DifficultyName
+                  difficulty={currentOverrideResult.categoryResult.difficultyLevel}
+                  mode={currentOverrideResult.categoryResult.mode}
+                />
+              ) : (
+                <DifficultyName
+                  difficulty={hoveredDifficulty.difficultyLevel}
+                  mode={hoveredDifficulty.mode}
+                />
+              )}
+            </Badge>
+          </Tooltip>
         )}
         {hoveredDifficulty.starRating != null && hoveredDifficulty.starRating > 0 && (
           <StarRatingBadge rating={hoveredDifficulty.starRating} />

--- a/electron-app/src/components/overview/objects/components/SnappingsOverview.tsx
+++ b/electron-app/src/components/overview/objects/components/SnappingsOverview.tsx
@@ -1,18 +1,100 @@
-import { Badge, Group, Paper, Stack, Table, Text, Title, useMantineTheme } from '@mantine/core';
-import { Fragment } from 'react';
-import { formatGameModeLabel, getModeAccentColor } from '../../../../utils/gameMode';
-import AppTable, {
-  DifficultyTableCell,
-  DifficultyTableHeaderCell,
-} from '../../../common/AppTable.tsx';
-import GameModeIcon from '../../../icons/GameModeIcon.tsx';
-import { getSnappingColumns } from '../timelineUtils.ts';
-import type { ObjectsModeGroup } from '../types.ts';
+import {
+  Badge,
+  Group,
+  Paper,
+  Popover,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  Title,
+  UnstyledButton,
+  useMantineTheme,
+} from "@mantine/core";
+import { CSSProperties, Fragment, type ReactNode, useMemo } from "react";
+import { formatGameModeLabel, getModeAccentColor } from "../../../../utils/gameMode";
+import AppTable, { DifficultyTableCell, DifficultyTableHeaderCell } from "../../../common/AppTable.tsx";
+import OsuLink from "../../../common/OsuLink.tsx";
+import GameModeIcon from "../../../icons/GameModeIcon.tsx";
+import { formatEditorTimestamp, getSnappingColumns } from "../timelineUtils.ts";
+import type { ObjectsModeGroup } from "../types.ts";
+
+function buildOsuTimestampLinkText(timesMs: number[]) {
+  if (timesMs.length === 0) return "";
+  return [...timesMs]
+    .sort((a, b) => a - b)
+    .map((ms) => `${formatEditorTimestamp(ms)} -`)
+    .join("\n");
+}
+
+function EdgeTimesPopover({
+  title,
+  timesMs,
+  children,
+  fullWidth = true,
+  hoverHighlightColor,
+}: {
+  title: string;
+  timesMs: number[];
+  children: ReactNode;
+  fullWidth?: boolean;
+  hoverHighlightColor?: string;
+}) {
+  const linkText = useMemo(() => buildOsuTimestampLinkText(timesMs), [timesMs]);
+
+  if (timesMs.length === 0) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Popover position="bottom" withArrow shadow="md" trapFocus={false}>
+      <Popover.Target>
+        <UnstyledButton
+          type="button"
+          p={0}
+          style={{
+            width: fullWidth ? "100%" : "auto",
+            display: fullWidth ? "block" : "inline-flex",
+            textAlign: "inherit",
+            verticalAlign: "inherit",
+            borderRadius: fullWidth ? undefined : 12,
+            transition: hoverHighlightColor ? "background-color 120ms" : undefined,
+          }}
+          onMouseEnter={
+            hoverHighlightColor
+              ? (event) => {
+                event.currentTarget.style.backgroundColor = hoverHighlightColor;
+              }
+              : undefined
+          }
+          onMouseLeave={
+            hoverHighlightColor
+              ? (event) => {
+                event.currentTarget.style.backgroundColor = "";
+              }
+              : undefined
+          }>
+          {children}
+        </UnstyledButton>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Text size="xs" c="dimmed" fw={600} mb="xs">
+          {title}
+        </Text>
+        <ScrollArea.Autosize mah={280} type="auto" offsetScrollbars>
+          <Text size="sm" component="div" style={{ whiteSpace: "pre-wrap" }}>
+            <OsuLink text={linkText} disableSeparators />
+          </Text>
+        </ScrollArea.Autosize>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
 
 function SnappingTableValue({ count, percentage }: { count: number; percentage: number }) {
   return (
     <Stack gap={0}>
-      <Text size="sm" fw={600} c={count === 0 ? 'dimmed' : undefined}>
+      <Text size="sm" fw={600} c={count === 0 ? "dimmed" : undefined}>
         {count.toLocaleString()}
       </Text>
       <Text size="xs" c="dimmed">
@@ -22,9 +104,17 @@ function SnappingTableValue({ count, percentage }: { count: number; percentage: 
   );
 }
 
-function SnappingStatusBadge({ count, percentage }: { count: number; percentage: number }) {
+function SnappingStatusBadge({
+  count,
+  percentage,
+  style,
+}: {
+  count: number;
+  percentage: number;
+  style?: CSSProperties;
+}) {
   return (
-    <Badge color={count > 0 ? 'yellow' : 'green'} variant="light">
+    <Badge color={count > 0 ? "yellow" : "green"} variant="light" style={style}>
       {count.toLocaleString()} ({percentage.toFixed(1)}%)
     </Badge>
   );
@@ -42,8 +132,8 @@ export default function SnappingsOverview({
   totalEdgeCount,
 }: SnappingsOverviewProps) {
   const theme = useMantineTheme();
-  const totalUnsnappedPercentage =
-    totalEdgeCount > 0 ? (totalUnsnappedCount * 100) / totalEdgeCount : 0;
+  const clickableCellHoverColor = theme.colors.dark[4];
+  const totalUnsnappedPercentage = totalEdgeCount > 0 ? (totalUnsnappedCount * 100) / totalEdgeCount : 0;
   const difficulties = groupedDifficulties.flatMap((group) => group.difficulties);
   const snappingColumns = getSnappingColumns(difficulties);
 
@@ -54,27 +144,27 @@ export default function SnappingsOverview({
           <Stack gap={2}>
             <Title order={4}>Snapping overview</Title>
             <Text size="sm" c="dimmed">
-              Counts are based on object edge times, including slider reverses and tails.
+              Click on a cell to see all timestamps for that snapping.
             </Text>
           </Stack>
-          <Badge color={totalUnsnappedCount > 0 ? 'yellow' : 'green'} variant="light">
+          <Badge color={totalUnsnappedCount > 0 ? "yellow" : "green"} variant="light">
             Unsnapped: {totalUnsnappedCount.toLocaleString()} ({totalUnsnappedPercentage.toFixed(1)}
             %)
           </Badge>
         </Group>
-        <AppTable>
+        <AppTable highlightOnHover={false}>
           <Table.Thead style={{ backgroundColor: theme.colors.dark[5] }}>
             <Table.Tr>
               <DifficultyTableHeaderCell>Difficulty</DifficultyTableHeaderCell>
               <Table.Th>Mode</Table.Th>
-              <Table.Th style={{ textAlign: 'center' }}>Objects</Table.Th>
-              <Table.Th style={{ textAlign: 'center' }}>Edges</Table.Th>
+              <Table.Th style={{ textAlign: "center" }}>Objects</Table.Th>
+              <Table.Th style={{ textAlign: "center" }}>Edges</Table.Th>
               {snappingColumns.map((column) => (
-                <Table.Th key={column.label} style={{ textAlign: 'center' }}>
+                <Table.Th key={column.label} style={{ textAlign: "center" }}>
                   {column.label}
                 </Table.Th>
               ))}
-              <Table.Th style={{ textAlign: 'center' }}>Unsnapped</Table.Th>
+              <Table.Th style={{ textAlign: "center" }}>Unsnapped</Table.Th>
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
@@ -112,23 +202,68 @@ export default function SnappingsOverview({
                     </Table.Td>
                     {snappingColumns.map((column) => {
                       const bucket = difficulty.snappings.find(
-                        (candidate) => candidate.label === column.label
+                        (candidate) => candidate.label === column.label,
                       );
+                      const timesMs = bucket?.edgeTimesMs ?? [];
+                      const count = bucket?.count ?? 0;
+                      const isClickable = timesMs.length > 0;
                       return (
-                        <Table.Td key={`${difficulty.mode}-${difficulty.version}-${column.label}`}>
-                          <SnappingTableValue
-                            count={bucket?.count ?? 0}
-                            percentage={bucket?.percentage ?? 0}
-                          />
+                        <Table.Td
+                          key={`${difficulty.mode}-${difficulty.version}-${column.label}`}
+                          style={{
+                            cursor: isClickable ? "pointer" : undefined,
+                            transition: isClickable ? "background-color 120ms" : undefined,
+                          }}
+                          onMouseEnter={
+                            isClickable
+                              ? (event) => {
+                                event.currentTarget.style.backgroundColor =
+                                  clickableCellHoverColor;
+                              }
+                              : undefined
+                          }
+                          onMouseLeave={
+                            isClickable
+                              ? (event) => {
+                                event.currentTarget.style.backgroundColor = "";
+                              }
+                              : undefined
+                          }>
+                          <EdgeTimesPopover
+                            title={`${column.label} snaps · ${difficulty.version}`}
+                            timesMs={timesMs}>
+                            <SnappingTableValue
+                              count={count}
+                              percentage={bucket?.percentage ?? 0}
+                            />
+                          </EdgeTimesPopover>
                         </Table.Td>
                       );
                     })}
-                    <Table.Td>
+                    <Table.Td
+                      style={{
+                        cursor:
+                          (difficulty.unsnappedEdgeTimesMs?.length ?? 0) > 0
+                            ? "pointer"
+                            : undefined,
+                      }}>
                       <Group justify="center" wrap="nowrap">
-                        <SnappingStatusBadge
-                          count={difficulty.unsnappedCount}
-                          percentage={difficulty.unsnappedPercentage}
-                        />
+                        <EdgeTimesPopover
+                          title={`Unsnapped objects · ${difficulty.version}`}
+                          timesMs={difficulty.unsnappedEdgeTimesMs ?? []}
+                          fullWidth={false}
+                          hoverHighlightColor={clickableCellHoverColor}>
+                          <SnappingStatusBadge
+                            count={difficulty.unsnappedCount}
+                            percentage={difficulty.unsnappedPercentage}
+                            style={{
+                              cursor:
+                                (difficulty.unsnappedEdgeTimesMs?.length ?? 0) > 0
+                                  ? "pointer"
+                                  : undefined,
+                            }}
+                          />
+                        </EdgeTimesPopover>
                       </Group>
                     </Table.Td>
                   </Table.Tr>

--- a/electron-app/src/components/snapshots/SnapshotCommitList.tsx
+++ b/electron-app/src/components/snapshots/SnapshotCommitList.tsx
@@ -9,6 +9,7 @@
   Flex,
   ScrollArea,
   ActionIcon,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconGitCommit,
@@ -141,7 +142,7 @@ function SnapshotCommitList({
         <IconChevronLeft size={20} />
       </ActionIcon>
       <ScrollArea
-        p="sm"
+        p="xs"
         bg={theme.colors.dark[8]}
         style={{ borderRadius: theme.radius.md, flex: 1 }}
         viewportRef={viewportRef}
@@ -163,36 +164,41 @@ function SnapshotCommitList({
                 }}
                 onClick={() => onSelectCommit(commit.id)}
                 style={{
-                  borderTop: `3px solid ${isSelected ? theme.colors.blue[6] : theme.colors.dark[5]}`,
+                  borderTop: `2px solid ${isSelected ? theme.colors.blue[6] : theme.colors.dark[5]}`,
                   backgroundColor: isSelected ? theme.colors.dark[6] : theme.colors.dark[7],
                   transition: 'all 0.15s ease',
                   borderRadius: theme.radius.sm,
-                  minWidth: '175px',
+                  minWidth: '145px',
                   flexShrink: 0,
                 }}
               >
-                <Box p="sm">
-                  <Stack gap="xs">
-                    <Group gap="xs" wrap="nowrap">
-                      <IconGitCommit
-                        size={18}
-                        color={isFirst ? theme.colors.green[5] : theme.colors.dark[3]}
-                        style={{ flexShrink: 0 }}
-                      />
-                      <Text size="sm" fw={500} truncate>
-                        {formatDate(commit.date)}
-                      </Text>
+                <Box px="xs" py={6}>
+                  <Stack gap="sm">
+                    <Group gap={6} wrap="nowrap" align="center">
+                      <Tooltip label="Latest Snapshot" disabled={!isFirst}>
+                        <Box style={{ display: 'flex', flexShrink: 0 }}>
+                          <IconGitCommit
+                            size={15}
+                            color={isFirst ? theme.colors.green[5] : theme.colors.dark[3]}
+                          />
+                        </Box>
+                      </Tooltip>
+                      <Group gap={4} wrap="nowrap" align="baseline" style={{ minWidth: 0, flex: 1 }}>
+                        <Text size="xs" fw={500} lh={1.1} truncate>
+                          {formatDate(commit.date)}
+                        </Text>
+                        <Text c="dimmed" fz="10px" lh={1.1} style={{ flexShrink: 0 }}>
+                          {formatTime(commit.date)}
+                        </Text>
+                      </Group>
                     </Group>
-                    <Text size="xs" c="dimmed">
-                      {formatTime(commit.date)}
-                    </Text>
-                    <Group gap="xs" wrap="nowrap">
+                    <Group gap={4} wrap="nowrap">
                       {commit.additions > 0 && (
                         <Badge
                           size="xs"
                           variant="light"
                           color="green"
-                          leftSection={<IconPlus size={10} />}
+                          leftSection={<IconPlus size={8} />}
                         >
                           {commit.additions}
                         </Badge>
@@ -202,7 +208,7 @@ function SnapshotCommitList({
                           size="xs"
                           variant="light"
                           color="red"
-                          leftSection={<IconMinus size={10} />}
+                          leftSection={<IconMinus size={8} />}
                         >
                           {commit.removals}
                         </Badge>
@@ -212,7 +218,7 @@ function SnapshotCommitList({
                           size="xs"
                           variant="light"
                           color="yellow"
-                          leftSection={<IconArrowsExchange size={10} />}
+                          leftSection={<IconArrowsExchange size={8} />}
                         >
                           {commit.modifications}
                         </Badge>


### PR DESCRIPTION
adds ability to view snap timestamps from the overview table

https://github.com/user-attachments/assets/61aa6a65-2198-4d31-98fb-4e6430048fc5

applies colors to interpreted difficulty badge, also helps with immediate visual cues when a diff isn't interpreted correctly on initial load

https://github.com/user-attachments/assets/9fee2d1c-4d93-4083-928d-d91d94f279a5

makes the snapshot list more compact

<img width="869" height="121" alt="image" src="https://github.com/user-attachments/assets/24ee3d8c-33db-47e1-ba59-2b6e1893d4da" />




