### PR TITLE
Make audio overview more compact

### DIFF
--- a/electron-app/src/components/overview/audio/AudioOverview.tsx
+++ b/electron-app/src/components/overview/audio/AudioOverview.tsx
@@ -1,7 +1,6 @@
 ﻿import { Alert, Text, Box, Flex, LoadingOverlay, Stack, SimpleGrid } from '@mantine/core';
 import { IconAlertCircle, IconAlertTriangle, IconRulerMeasure } from '@tabler/icons-react';
 import { useEffect } from 'react';
-import BitrateGraph from './BitrateGraph';
 import ChannelBalance from './ChannelBalance';
 import DynamicRange from './DynamicRange';
 import FormatInfo from './FormatInfo';
@@ -93,9 +92,12 @@ function AudioOverview({ reloadFlag }: AudioOverviewProps) {
           )}
           <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
             {data.formatAnalysis && (
-              <FormatInfo data={data.formatAnalysis} audioFilePath={data.audioFilePath} />
+              <FormatInfo
+                data={data.formatAnalysis}
+                audioFilePath={data.audioFilePath}
+                bitrateData={data.bitrateAnalysis}
+              />
             )}
-            {data.bitrateAnalysis && <BitrateGraph data={data.bitrateAnalysis} />}
             <Spectrogram folder={folder} songFolder={settings.songFolder ?? ''} />
           </SimpleGrid>
 

--- a/electron-app/src/components/overview/audio/BitrateProgressIndicator.tsx
+++ b/electron-app/src/components/overview/audio/BitrateProgressIndicator.tsx
@@ -1,0 +1,127 @@
+import { Box, Group, Progress, Stack, Text, Tooltip, useMantineTheme } from '@mantine/core';
+import { BitrateAnalysisResult } from '../../../Types';
+
+interface BitrateProgressIndicatorProps {
+  bitrateData: BitrateAnalysisResult;
+}
+
+function BitrateProgressIndicator({ bitrateData }: BitrateProgressIndicatorProps) {
+  const theme = useMantineTheme();
+  const displayMinBitrate = 64;
+  const displayMaxBitrate = 320;
+  const displayRange = displayMaxBitrate - displayMinBitrate;
+
+  const isAverageBitrateOutOfRange =
+    bitrateData.averageBitrate < bitrateData.minAllowedBitrate ||
+    bitrateData.averageBitrate > bitrateData.maxAllowedBitrate;
+
+  const averageBitratePositionPercent = Math.min(
+    100,
+    Math.max(0, ((bitrateData.averageBitrate - displayMinBitrate) / displayRange) * 100)
+  );
+  const minAllowedPositionPercent = Math.min(
+    100,
+    Math.max(0, ((bitrateData.minAllowedBitrate - displayMinBitrate) / displayRange) * 100)
+  );
+  const maxAllowedPositionPercent = Math.min(
+    100,
+    Math.max(0, ((bitrateData.maxAllowedBitrate - displayMinBitrate) / displayRange) * 100)
+  );
+  const allowedZonePercent = Math.max(0, maxAllowedPositionPercent - minAllowedPositionPercent);
+  const markerColor = bitrateData.isCompliant ? theme.colors.blue[4] : theme.colors.orange[4];
+  const averageBitrateRangeDirection =
+    bitrateData.averageBitrate < bitrateData.minAllowedBitrate
+      ? 'below'
+      : bitrateData.averageBitrate > bitrateData.maxAllowedBitrate
+        ? 'above'
+        : null;
+
+  return (
+    <Stack gap={4}>
+      <Group justify="space-between" align="flex-start" mb="xs">
+        <Stack gap={0}>
+          <Text size="xs" c="dimmed" tt="uppercase">
+            Average Bitrate
+          </Text>
+          <Text fw={700} size="xl" c={isAverageBitrateOutOfRange ? 'red.4' : undefined}>
+            {bitrateData.averageBitrate.toLocaleString()} kbps
+          </Text>
+        </Stack>
+        <Text size="xs" c="dimmed" ta="right">
+          Allowed: {bitrateData.minAllowedBitrate.toLocaleString()}-
+          {bitrateData.maxAllowedBitrate.toLocaleString()} kbps
+        </Text>
+      </Group>
+
+      <Box pos="relative" mb={4}>
+        <Progress.Root size={8} radius="xl" bg={theme.colors.dark[4]}>
+          <Progress.Section value={minAllowedPositionPercent} color="red.6" />
+          <Progress.Section value={allowedZonePercent} color="green.6" />
+          <Progress.Section value={100 - maxAllowedPositionPercent} color="red.6" />
+        </Progress.Root>
+        <Tooltip label={`${bitrateData.averageBitrate.toLocaleString()} kbps`} withArrow>
+          <Box
+            pos="absolute"
+            top={-6}
+            left={`calc(${averageBitratePositionPercent}% - 1.5px)`}
+            w={6}
+            h={20}
+            bg={markerColor}
+            style={{
+              borderRadius: 999,
+              border: `1px solid ${theme.colors.dark[4]}`,
+              cursor: 'pointer',
+            }}
+          />
+        </Tooltip>
+      </Box>
+
+      <Box pos="relative" h={16}>
+        <Text
+          size="xs"
+          c="dimmed"
+          pos="absolute"
+          left="0%"
+          style={{ transform: 'translateX(0)' }}
+        >
+          64 kbps
+        </Text>
+        <Text
+          size="xs"
+          c="dimmed"
+          pos="absolute"
+          left={`${minAllowedPositionPercent}%`}
+          style={{ transform: 'translateX(-50%)' }}
+        >
+          {bitrateData.minAllowedBitrate.toLocaleString()} kbps
+        </Text>
+        <Text
+          size="xs"
+          c="dimmed"
+          pos="absolute"
+          left={`${maxAllowedPositionPercent}%`}
+          style={{ transform: 'translateX(-50%)' }}
+        >
+          {bitrateData.maxAllowedBitrate.toLocaleString()} kbps
+        </Text>
+        <Text
+          size="xs"
+          c="dimmed"
+          pos="absolute"
+          left="100%"
+          style={{ transform: 'translateX(-100%)', whiteSpace: 'nowrap' }}
+        >
+          320 kbps
+        </Text>
+      </Box>
+
+      {isAverageBitrateOutOfRange && (
+        <Text size="xs" c="red.4" mt={2}>
+          Average bitrate is {averageBitrateRangeDirection} the allowed range.
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+export default BitrateProgressIndicator;

--- a/electron-app/src/components/overview/audio/FormatInfo.tsx
+++ b/electron-app/src/components/overview/audio/FormatInfo.tsx
@@ -12,11 +12,13 @@
   Box,
 } from '@mantine/core';
 import { IconCheck, IconX, IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
-import { FormatAnalysisResult } from '../../../Types';
+import BitrateProgressIndicator from './BitrateProgressIndicator.tsx';
+import { BitrateAnalysisResult, FormatAnalysisResult } from '../../../Types';
 
 interface FormatInfoProps {
   data: FormatAnalysisResult;
   audioFilePath: string;
+  bitrateData?: BitrateAnalysisResult | null;
 }
 
 function getBadgeColor(badgeType: string): string {
@@ -32,7 +34,7 @@ function getBadgeColor(badgeType: string): string {
   }
 }
 
-function FormatInfo({ data, audioFilePath }: FormatInfoProps) {
+function FormatInfo({ data, audioFilePath, bitrateData }: FormatInfoProps) {
   const theme = useMantineTheme();
 
   // Check if sample rate exceeds 48 kHz
@@ -121,6 +123,38 @@ function FormatInfo({ data, audioFilePath }: FormatInfoProps) {
           </Text>
         </Stack>
       </SimpleGrid>
+
+      {bitrateData && (
+        <>
+          <Group justify="space-between" mb="xs">
+            <Group gap="xs">
+              <Text fw={600} size="sm">
+                Bitrate
+              </Text>
+              <Tooltip
+                label="Bitrate represents the amount of data used per second of audio. Higher bitrates generally preserve more detail but result in larger file sizes."
+                multiline
+                w={250}
+              >
+                <IconInfoCircle size={14} style={{ color: theme.colors.gray[6], cursor: 'help' }} />
+              </Tooltip>
+            </Group>
+            <Group gap="xs">
+              <Badge color={bitrateData.isCompliant ? 'green' : 'red'} variant="light">
+                {bitrateData.isCompliant ? 'Compliant' : 'Non-Compliant'}
+              </Badge>
+              {bitrateData.isVbr && (
+                <Badge color="blue" variant="light">
+                  VBR
+                </Badge>
+              )}
+            </Group>
+          </Group>
+          <Box p="sm" mb="md" bg={theme.colors.dark[6]} style={{ borderRadius: theme.radius.sm }}>
+            <BitrateProgressIndicator bitrateData={bitrateData} />
+          </Box>
+        </>
+      )}
 
       {/* Format Requirements Summary */}
       <Box p="xs" mb="md" bg={theme.colors.dark[6]} style={{ borderRadius: theme.radius.sm }}>


### PR DESCRIPTION
bitrate takes too much empty space when in its own section, so I merged it with the format one and remade its design to use a position indicator

<img width="1649" height="688" alt="image" src="https://github.com/user-attachments/assets/bdac832e-fbc7-494b-91ff-b74e53341821" />
