### PR TITLE
refactor changelog handling

### DIFF
--- a/electron-app/src/components/documentation/MantineMarkdown.tsx
+++ b/electron-app/src/components/documentation/MantineMarkdown.tsx
@@ -20,15 +20,28 @@ interface MantineMarkdownProps {
 export default function MantineMarkdown({ children }: MantineMarkdownProps) {
   const theme = useMantineTheme();
   const { colorScheme } = useMantineColorScheme();
+  const hasLeadingContent = (node: unknown): boolean => {
+    if (!node || typeof node !== 'object') return false;
+    const start = (node as Record<string, unknown>).position as
+      | { start?: { offset?: number } }
+      | undefined;
+    return (start?.start?.offset ?? 0) > 0;
+  };
 
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
-        h1: ({ node: _node, ...props }) => <Title order={2} {...props} />,
-        h2: ({ node: _node, ...props }) => <Title order={3} {...props} />,
-        h3: ({ node: _node, ...props }) => <Title order={4} {...props} />,
-        p: ({ node: _node, ...props }) => <Text component="p" {...props} />,
+        h1: ({ node, ...props }) => (
+          <Title order={2} mt={hasLeadingContent(node) ? 'md' : 0} mb="sm" {...props} />
+        ),
+        h2: ({ node, ...props }) => (
+          <Title order={3} mt={hasLeadingContent(node) ? 'md' : 0} mb="sm" {...props} />
+        ),
+        h3: ({ node, ...props }) => (
+          <Title order={4} mt={hasLeadingContent(node) ? 'sm' : 0} mb="xs" {...props} />
+        ),
+        p: ({ node: _node, ...props }) => <Text component="p" mb="sm" {...props} />,
         a: ({ node: _node, href, ...props }) => {
           const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
             e.preventDefault();

--- a/electron-app/src/components/home/Changelog.tsx
+++ b/electron-app/src/components/home/Changelog.tsx
@@ -1,69 +1,158 @@
-import { Card, Stack, Title } from '@mantine/core';
-import changelog from '../../content/CHANGELOG.md?raw';
+import { Badge, Card, Collapse, Group, Stack, Text, Title } from '@mantine/core';
+import { IconChevronDown } from '@tabler/icons-react';
+import { useState } from 'react';
 import MantineMarkdown from '../documentation/MantineMarkdown.tsx';
 
-interface ChangelogRelease {
+interface ChangelogEntry {
+  version: string;
   title: string;
   body: string;
+  previewLine: string | null;
 }
 
-function parseChangelog(raw: string): {
-  pageHeading: string | null;
-  intro: string | null;
-  releases: ChangelogRelease[];
-} {
-  const parts = raw.trim().split(/\n(?=## )/);
-  const first = parts[0]?.trim() ?? '';
+function parseSemver(version: string): [number, number, number] {
+  const [major, minor, patch] = version.split('.').map((part) => Number.parseInt(part, 10));
+  return [major || 0, minor || 0, patch || 0];
+}
 
-  let pageHeading: string | null = null;
-  let intro: string | null = null;
+function compareSemverDesc(a: string, b: string): number {
+  const aParts = parseSemver(a);
+  const bParts = parseSemver(b);
 
-  const h1Match = first.match(/^#\s+(.+?)(?:\n|$)/);
-  if (h1Match) {
-    pageHeading = h1Match[1].trim();
-    const afterH1 = first.slice(h1Match[0].length).trim();
-    intro = afterH1 || null;
-  } else if (first) {
-    intro = first;
+  for (let i = 0; i < 3; i += 1) {
+    if (aParts[i] !== bParts[i]) {
+      return bParts[i] - aParts[i];
+    }
   }
 
-  const releaseParts = h1Match ? parts.slice(1) : parts;
-  const releases: ChangelogRelease[] = [];
+  return 0;
+}
 
-  for (const block of releaseParts) {
-    const trimmed = block.trim();
-    if (!trimmed.startsWith('##')) continue;
-    const lines = trimmed.split('\n');
-    const title = lines[0].replace(/^##\s+/, '').trim();
+function getPreviewLine(body: string): string | null {
+  const firstContentLine = body
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  return firstContentLine ?? null;
+}
+
+function parseEntry(raw: string, version: string): ChangelogEntry {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { version, title: `[${version}]`, body: '', previewLine: null };
+  }
+
+  const lines = trimmed.split('\n');
+  const firstLine = lines[0].trim();
+
+  if (firstLine.startsWith('## ')) {
     const body = lines.slice(1).join('\n').trim();
-    releases.push({ title, body });
+    return {
+      version,
+      title: firstLine.replace(/^##\s+/, '').trim(),
+      body,
+      previewLine: getPreviewLine(body),
+    };
   }
 
-  return { pageHeading, intro, releases };
+  return { version, title: `[${version}]`, body: trimmed, previewLine: getPreviewLine(trimmed) };
+}
+
+function loadEntries(): ChangelogEntry[] {
+  const changelogFiles = import.meta.glob('../../content/changelog/*.md', {
+    eager: true,
+    import: 'default',
+    query: '?raw',
+  }) as Record<string, string>;
+
+  return Object.entries(changelogFiles)
+    .map(([path, raw]) => {
+      const match = path.match(/[\\/](\d+\.\d+\.\d+)\.md$/);
+      if (!match) return null;
+      return parseEntry(raw, match[1]);
+    })
+    .filter((entry): entry is ChangelogEntry => entry !== null)
+    .sort((a, b) => compareSemverDesc(a.version, b.version));
 }
 
 export default function Changelog() {
-  const { pageHeading, intro, releases } = parseChangelog(changelog);
+  const entries = loadEntries();
+  const [expandedVersions, setExpandedVersions] = useState<Set<string>>(
+    () => new Set(entries[0] ? [entries[0].version] : [])
+  );
+
+  const toggleEntry = (version: string) => {
+    setExpandedVersions((prev) => {
+      const next = new Set(prev);
+      if (next.has(version)) {
+        next.delete(version);
+      } else {
+        next.add(version);
+      }
+      return next;
+    });
+  };
 
   return (
     <Stack gap="md">
-      {pageHeading && (
-        <Title order={2} fw={600}>
-          {pageHeading}
-        </Title>
-      )}
-      {intro && <MantineMarkdown>{intro}</MantineMarkdown>}
+      <Title order={2} fw={600}>
+        Changelog
+      </Title>
 
-      {releases.map((release, index) => (
-        <Card key={`${release.title}-${index}`} withBorder padding="lg" radius="md" shadow="sm">
-          <Stack gap="sm">
-            <Title order={3} fw={600}>
-              {release.title}
-            </Title>
-            {release.body ? <MantineMarkdown>{release.body}</MantineMarkdown> : null}
-          </Stack>
-        </Card>
-      ))}
+      {entries.length === 0 ? <Text c="dimmed">No changelog entries yet.</Text> : null}
+
+      {entries.map((entry, index) => {
+        const isExpanded = expandedVersions.has(entry.version);
+        const isLatest = index === 0;
+
+        return (
+          <Card
+            key={entry.version}
+            withBorder
+            padding="lg"
+            radius="md"
+            shadow="sm"
+            onClick={() => toggleEntry(entry.version)}
+            style={{ cursor: 'pointer' }}
+          >
+            <Stack gap="sm">
+              <div style={{ width: '100%', textAlign: 'left' }}>
+                <Group justify="space-between" align="center">
+                  <Group gap="xs" align="center">
+                    <Text component="h3" fw={700} fz="1.6rem" lh={1.15} m={0}>
+                      {entry.title}
+                    </Text>
+                    {isLatest ? (
+                      <Badge size="md" variant="light" color="blue">
+                        Latest
+                      </Badge>
+                    ) : null}
+                  </Group>
+                  <IconChevronDown
+                    size={18}
+                    style={{
+                      transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                      transition: 'transform 150ms ease',
+                    }}
+                  />
+                </Group>
+                {!isExpanded && entry.previewLine ? (
+                  <Text c="dimmed" size="sm" mt="xs" lineClamp={2}>
+                    {entry.previewLine}
+                  </Text>
+                ) : null}
+              </div>
+
+              <div onClick={(event) => event.stopPropagation()}>
+                <Collapse in={isExpanded}>
+                  {entry.body ? <MantineMarkdown>{entry.body}</MantineMarkdown> : null}
+                </Collapse>
+              </div>
+            </Stack>
+          </Card>
+        );
+      })}
     </Stack>
   );
 }

--- a/electron-app/src/content/changelog/2.0.0.md
+++ b/electron-app/src/content/changelog/2.0.0.md
@@ -1,5 +1,3 @@
-﻿# Changelog
-
 ## [2.0.0] - 2026-05-05
 
 Welcome to MV 2.0!


### PR DESCRIPTION
can now create 1 file per changelog entry, latest one always expanded, rest are collapsed