### PR TITLE
Fix inconsistent int cast in CheckHitSoundImbalance

### DIFF
--- a/MapsetVerifier.Checks/AllModes/General/Audio/CheckHitSoundImbalance.cs
+++ b/MapsetVerifier.Checks/AllModes/General/Audio/CheckHitSoundImbalance.cs
@@ -131,8 +131,8 @@ namespace MapsetVerifier.Checks.AllModes.General.Audio
                 if (peaks.Count == 0)
                     continue;
 
-                var leftSum = peaks.Sum(peak => (int)peak[0]);
-                var rightSum = peaks.Sum(peak => peak.Length > 1 ? peak[1] : 0);
+                var leftSum = peaks.Sum(peak => peak[0]);
+                var rightSum = peaks.Sum(peak => peak.Length > 1 ? peak[1] : 0f);
 
                 if (leftSum == 0 || rightSum == 0)
                 {

--- a/MapsetVerifier.Checks/AllModes/General/Audio/CheckHitSoundImbalance.cs
+++ b/MapsetVerifier.Checks/AllModes/General/Audio/CheckHitSoundImbalance.cs
@@ -140,7 +140,7 @@ namespace MapsetVerifier.Checks.AllModes.General.Audio
                         GetTemplate("Warning Silent"),
                         null,
                         hsFile,
-                        leftSum - rightSum > 0 ? "left" : "right"
+                        leftSum - rightSum < 0 ? "left" : "right"
                     );
 
                     continue;


### PR DESCRIPTION
At the moment in `CheckHitSoundImbalance` the peaks of the left channel are being cast to integers before the sum, whereas the ones on the right are being kept as floats. This leads to the louder channel issue being triggered even if the peaks are the exact same in value.

I ended up keeping both sums as floats, as from what I've seen there's no real reason to use integers over them (the silent warning should still work correctly, as it should be triggered only when the hs file has no data, without the need for epsilon comparions)

(original issue can be reproduced with https://osu.ppy.sh/beatmapsets/2551034 for reference)