### PR TITLE
Fix tail hitsounds changes being ignored in snapshot

### DIFF
--- a/MapsetVerifier.Snapshots/Translators/HitObjectsTranslator.cs
+++ b/MapsetVerifier.Snapshots/Translators/HitObjectsTranslator.cs
@@ -363,16 +363,16 @@ namespace MapsetVerifier.Snapshots.Translators
                     )
                     {
                         if (
-                            addedSlider.HasHitSound(hitSound)
-                            && !removedSlider.HasHitSound(hitSound)
+                            addedSlider.EndHitSound.HasFlag(hitSound)
+                            && !removedSlider.EndHitSound.HasFlag(hitSound)
                         )
                             yield return "Added "
                                 + Enum.GetName(typeof(HitObject.HitSounds), hitSound)?.ToLower()
                                 + " to tail.";
 
                         if (
-                            !addedSlider.HasHitSound(hitSound)
-                            && removedSlider.HasHitSound(hitSound)
+                            !addedSlider.EndHitSound.HasFlag(hitSound)
+                            && removedSlider.EndHitSound.HasFlag(hitSound)
                         )
                             yield return "Removed "
                                 + Enum.GetName(typeof(HitObject.HitSounds), hitSound)?.ToLower()


### PR DESCRIPTION
At the moment the code incorrectly looks at slider general hitsounds for tail hitsound changes rather than the correct end hitsound field for some reason. This should fix it