### PR TITLE
Improve difficulty matching based on name

### DIFF
--- a/MapsetVerifier.Parser.Tests/Objects/BeatmapTests.cs
+++ b/MapsetVerifier.Parser.Tests/Objects/BeatmapTests.cs
@@ -1,0 +1,114 @@
+﻿using MapsetVerifier.Parser.Objects;
+using Xunit;
+
+namespace MapsetVerifier.Parser.Tests.Objects;
+
+public class BeatmapTests
+{
+    private Beatmap CreateBeatmap(string version, Beatmap.Mode mode = Beatmap.Mode.Standard)
+    {
+        var code =
+$"""
+[General]
+Mode: {(int) mode}
+
+[Metadata]
+Version:{version}
+
+[Difficulty]
+HP:5
+""";
+
+        return new Beatmap(code, "song", "map.osu");
+    }
+
+    [Fact]
+    public void DirectMatch_Kantan_ReturnsEasy()
+    {
+        var beatmap = CreateBeatmap("Kantan", Beatmap.Mode.Taiko);
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Equal(Beatmap.Difficulty.Easy, result);
+    }
+
+    [Fact]
+    public void DecoratedName_StillMatches_Kantan()
+    {
+        var beatmap = CreateBeatmap("~Kantan~", Beatmap.Mode.Taiko);
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Equal(Beatmap.Difficulty.Easy, result);
+    }
+
+    [Fact]
+    public void CollabPrefix_IsIgnored()
+    {
+        var beatmap = CreateBeatmap("Collab Kantan", Beatmap.Mode.Taiko);
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Equal(Beatmap.Difficulty.Easy, result);
+    }
+
+    [Fact]
+    public void OwnerPrefix_IsIgnored()
+    {
+        var beatmap = CreateBeatmap("Greaper's Kantan", Beatmap.Mode.Taiko);
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Equal(Beatmap.Difficulty.Easy, result);
+    }
+
+    [Fact]
+    public void InnerOni_IsCorrectlyMatched()
+    {
+        var beatmap = CreateBeatmap("Greaper's Inner Oni", Beatmap.Mode.Taiko);
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Equal(Beatmap.Difficulty.Expert, result);
+    }
+
+    [Fact]
+    public void NoiseDoesNotCreateFalsePositive()
+    {
+        var beatmap = CreateBeatmap("Nothing Comes Easy");
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void EasySubstringDoesNotMatchInsideWord()
+    {
+        var beatmap = CreateBeatmap("NotAnEasyMap");
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CaseInsensitivity_Works()
+    {
+        var beatmap = CreateBeatmap("kAnTaN", Beatmap.Mode.Taiko);
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Equal(Beatmap.Difficulty.Easy, result);
+    }
+
+    [Fact]
+    public void ModeSpecificMapping_Taiko_Oni()
+    {
+        var beatmap = CreateBeatmap("Oni", Beatmap.Mode.Taiko);
+
+        var result = beatmap.GetDifficultyFromName();
+
+        Assert.Equal(Beatmap.Difficulty.Insane, result);
+    }
+}

--- a/MapsetVerifier.Parser.Tests/Objects/BeatmapTests.cs
+++ b/MapsetVerifier.Parser.Tests/Objects/BeatmapTests.cs
@@ -7,10 +7,9 @@ public class BeatmapTests
 {
     private Beatmap CreateBeatmap(string version, Beatmap.Mode mode = Beatmap.Mode.Standard)
     {
-        var code =
-$"""
+        var code = $"""
 [General]
-Mode: {(int) mode}
+Mode: {(int)mode}
 
 [Metadata]
 Version:{version}

--- a/MapsetVerifier.Parser/Objects/Beatmap.cs
+++ b/MapsetVerifier.Parser/Objects/Beatmap.cs
@@ -15,7 +15,7 @@ using osu.Game.Rulesets.Difficulty.Skills;
 
 namespace MapsetVerifier.Parser.Objects
 {
-    public class Beatmap
+    public partial class Beatmap
     {
         /// <summary> Which type of difficulty level the beatmap is considered. </summary>
         public enum Difficulty
@@ -174,6 +174,7 @@ namespace MapsetVerifier.Parser.Objects
                 }
             },
         };
+        private static readonly Dictionary<Mode, Dictionary<string, Difficulty>> DifficultyIndex = new();
 
         public string Code { get; }
         public string SongPath { get; }
@@ -232,6 +233,25 @@ namespace MapsetVerifier.Parser.Objects
         public List<HitObject> HitObjects { get; }
         public List<TimingLine> TimingLines { get; }
 
+        static Beatmap()
+        {
+            foreach (var mode in NameDiffPairs)
+            {
+                var map = new Dictionary<string, Difficulty>();
+
+                foreach (var (difficulty, names) in mode.Value)
+                {
+                    foreach (var name in names)
+                    {
+                        var key = GetRelevantPartOfDifficultyName(name);
+                        map[key] = difficulty;
+                    }
+                }
+
+                DifficultyIndex[mode.Key] = map;
+            }
+        }
+        
         public Beatmap(string code, string songPath, string mapPath)
         {
             Code = code;
@@ -832,10 +852,6 @@ namespace MapsetVerifier.Parser.Objects
                     return difficultyFromStarRating;
                 }
 
-                var levelGap = Math.Abs((int)interpretedFromName - (int)difficultyFromStarRating);
-                if (levelGap >= 2)
-                    return difficultyFromStarRating;
-
                 return interpretedFromName;
             }
 
@@ -856,24 +872,31 @@ namespace MapsetVerifier.Parser.Objects
             };
         }
 
+        private static string GetRelevantPartOfDifficultyName(string input)
+        {
+            input = input.ToLowerInvariant();
+
+            // Remove indication of ownership
+            input = OwnerPrefixRegex().Replace(input, "");
+            input = CollabRegex().Replace(input, "");
+            
+            input = SpecialCharactersRegex().Replace(input, " ");
+            input = WhiteSpaceCleanupRegex().Replace(input, " ").Trim();
+
+            return input;
+        }
+
         public Difficulty? GetDifficultyFromName()
         {
-            var name = MetadataSettings.version;
+            var name = GetRelevantPartOfDifficultyName(MetadataSettings.version);
 
-            // Reverse order allows e.g. "Inner Oni"/"Black Another" to be looked for separately from just "Oni"/"Another".
-            var pairs = NameDiffPairs[GeneralSettings.mode].Reverse();
+            var map = DifficultyIndex[GeneralSettings.mode];
 
-            foreach (var pair in pairs)
-                // Allows difficulty names such as "Normal...!??" and ">{(__HARD;)}" to be detected,
-                // but still prevents "Normality" or similar inclusions.
-                if (
-                    pair.Value.Any(value =>
-                        new Regex(@$"(?i)(^| )[!-@\[-`{{-~]*{value}[!-@\[-`{{-~]*( |$)").IsMatch(
-                            name
-                        )
-                    )
-                )
-                    return pair.Key;
+            // Only do direct matching to avoid false positives
+            if (map.TryGetValue(name, out var diff))
+            {
+                return diff;
+            }
 
             return null;
         }
@@ -1428,5 +1451,14 @@ namespace MapsetVerifier.Parser.Objects
             // Works under the assumption that hit objects and timing lines are immutable per beatmap id, which is the case.
             internal static readonly ConcurrentDictionary<(string, Type), List<T>> cache = new();
         }
+
+        [GeneratedRegex(@"^\s*\w+'s\s+")]
+        private static partial Regex OwnerPrefixRegex();
+        [GeneratedRegex(@"\bcollab\b")]
+        private static partial Regex CollabRegex();
+        [GeneratedRegex(@"[^a-z0-9\s]")]
+        private static partial Regex SpecialCharactersRegex();
+        [GeneratedRegex(@"\s+")]
+        private static partial Regex WhiteSpaceCleanupRegex();
     }
 }

--- a/MapsetVerifier.Parser/Objects/Beatmap.cs
+++ b/MapsetVerifier.Parser/Objects/Beatmap.cs
@@ -825,10 +825,7 @@ namespace MapsetVerifier.Parser.Objects
         }
 
         /// <summary>
-        ///     Returns the interpreted difficulty level based on the star rating of the beatmap
-        ///     (may be inaccurate since recent sr reworks were done), can optionally consider diff names.
-        ///     When the name can be parsed, it wins if it disagrees with SR by at most one step on the
-        ///     Easy→Ultra scale; if the gap is two or more steps, SR is used instead.
+        /// Returns the interpreted difficulty level based on difficulty name or fallback on star rating
         /// </summary>
         public Difficulty GetDifficulty()
         {
@@ -836,27 +833,26 @@ namespace MapsetVerifier.Parser.Objects
             if (InterpretedDifficultyOverride is { } overridden)
                 return overridden;
 
-            var difficultyFromStarRating = GetDifficultyFromStarRating();
             var difficultyFromName = GetDifficultyFromName();
 
-            if (difficultyFromName != null)
+            // We can't determine the difficulty by name so instead use star rating
+            if (difficultyFromName == null)
             {
-                var interpretedFromName = (Difficulty)difficultyFromName;
-                // Broad osu!taiko "Oni" labels map to Insane by name, but trust SR when it clearly maps to Expert or Ultra.
-                if (
-                    GeneralSettings.mode == Mode.Taiko
-                    && interpretedFromName == Difficulty.Insane
-                    && difficultyFromStarRating >= Difficulty.Expert
-                )
+                return GetDifficultyFromStarRating();
+            }
+
+            var interpretedFromName = (Difficulty)difficultyFromName;
+            // Broad osu!taiko "Oni" labels map to Insane by name, but trust SR when it clearly maps to Expert or Ultra.
+            if (GeneralSettings.mode == Mode.Taiko && interpretedFromName == Difficulty.Insane)
+            {
+                var difficultyFromStarRating = GetDifficultyFromStarRating();
+                if (difficultyFromStarRating >= Difficulty.Expert)
                 {
                     return difficultyFromStarRating;
                 }
-
-                return interpretedFromName;
             }
 
-            // We can't determine the difficulty by name so instead use star rating
-            return difficultyFromStarRating;
+            return interpretedFromName;
         }
 
         private Difficulty GetDifficultyFromStarRating()

--- a/MapsetVerifier.Parser/Objects/Beatmap.cs
+++ b/MapsetVerifier.Parser/Objects/Beatmap.cs
@@ -174,7 +174,8 @@ namespace MapsetVerifier.Parser.Objects
                 }
             },
         };
-        private static readonly Dictionary<Mode, Dictionary<string, Difficulty>> DifficultyIndex = new();
+        private static readonly Dictionary<Mode, Dictionary<string, Difficulty>> DifficultyIndex =
+            new();
 
         public string Code { get; }
         public string SongPath { get; }
@@ -251,7 +252,7 @@ namespace MapsetVerifier.Parser.Objects
                 DifficultyIndex[mode.Key] = map;
             }
         }
-        
+
         public Beatmap(string code, string songPath, string mapPath)
         {
             Code = code;
@@ -875,7 +876,7 @@ namespace MapsetVerifier.Parser.Objects
             // Remove indication of ownership
             input = OwnerPrefixRegex().Replace(input, "");
             input = CollabRegex().Replace(input, "");
-            
+
             input = SpecialCharactersRegex().Replace(input, " ");
             input = WhiteSpaceCleanupRegex().Replace(input, " ").Trim();
 
@@ -1450,10 +1451,13 @@ namespace MapsetVerifier.Parser.Objects
 
         [GeneratedRegex(@"^\s*\w+'s\s+")]
         private static partial Regex OwnerPrefixRegex();
+
         [GeneratedRegex(@"\bcollab\b")]
         private static partial Regex CollabRegex();
+
         [GeneratedRegex(@"[^a-z0-9\s]")]
         private static partial Regex SpecialCharactersRegex();
+
         [GeneratedRegex(@"\s+")]
         private static partial Regex WhiteSpaceCleanupRegex();
     }

--- a/electron-app/src/App.tsx
+++ b/electron-app/src/App.tsx
@@ -77,9 +77,9 @@ function AppContent() {
                           h="calc(100vh - var(--app-shell-header-offset, 0rem) + var(--app-shell-padding))"
                         >
                           <Container p="sm" fluid>
-                              <RouteErrorBoundary>
-                                <BeatmapKeyedOutlet />
-                              </RouteErrorBoundary>
+                            <RouteErrorBoundary>
+                              <BeatmapKeyedOutlet />
+                            </RouteErrorBoundary>
                           </Container>
                         </ScrollArea>
                       </AppShell.Main>

--- a/electron-app/src/components/overview/objects/hooks/useTimelineScrollTickStep.ts
+++ b/electron-app/src/components/overview/objects/hooks/useTimelineScrollTickStep.ts
@@ -1,8 +1,5 @@
 import { useCallback, useState } from 'react';
-import {
-  TIMELINE_SCROLL_TICK_STEP_OPTIONS,
-  type TimelineScrollTickStep,
-} from '../constants.ts';
+import { TIMELINE_SCROLL_TICK_STEP_OPTIONS, type TimelineScrollTickStep } from '../constants.ts';
 
 const DEFAULT_TICK_STEP: TimelineScrollTickStep = 2;
 


### PR DESCRIPTION
Uses a different approach which does the following:
1. Removes any possession of a difficulty (to avoid cases such as "Easy's ..." to be interpreted as Easy)
2. Remove any special characters
3. Remove and strip any unneeded whitespaces

Properly resolves #97