### PR TITLE
Properly check and report underscore tags only for guests with single character components in names

### DIFF
--- a/MapsetVerifier.Checks/AllModes/General/Metadata/CheckGuestTags.cs
+++ b/MapsetVerifier.Checks/AllModes/General/Metadata/CheckGuestTags.cs
@@ -56,8 +56,10 @@ namespace MapsetVerifier.Checks.AllModes.General.Metadata
             foreach (var beatmap in beatmapSet.Beatmaps)
             foreach (var possessor in GetAllPossessors(beatmap.MetadataSettings.version))
             {
+                var possessorTag = BuildPossessorTag(possessor);
+
                 if (
-                    beatmap.MetadataSettings.IsCoveredByTags(possessor)
+                    beatmap.MetadataSettings.IsCoveredByTags(possessorTag)
                     || beatmap.MetadataSettings.creator.ToLower() == possessor.ToLower()
                 )
                     continue;
@@ -66,9 +68,19 @@ namespace MapsetVerifier.Checks.AllModes.General.Metadata
                     GetTemplate("Warning"),
                     null,
                     beatmap.MetadataSettings.version,
-                    possessor.ToLower().Replace(" ", "_")
+                    possessorTag
                 );
             }
+        }
+
+        private string BuildPossessorTag(string possessor)
+        {
+            var components = possessor.Split(" ");
+            bool hasSingleCharacterComponents = components.Any(p => p.Length == 1);
+
+            return hasSingleCharacterComponents
+                ? string.Join("_", components).ToLower()
+                : possessor.ToLower();
         }
 
         /// <summary>
@@ -104,7 +116,10 @@ namespace MapsetVerifier.Checks.AllModes.General.Metadata
         /// </summary>
         private IEnumerable<string> GetAllPossessors(string text)
         {
-            return text.Split(collabChars).Select(GetPossessor).OfType<string>();
+            return text.Split(collabChars)
+                .Select(GetPossessor)
+                .Where(p => !string.IsNullOrEmpty(p))
+                .OfType<string>();
         }
     }
 }


### PR DESCRIPTION
Fixes https://discord.com/channels/316154420591067136/1505419546041909308/1512868104928100432, and should also fix the lookup logic for tags in this case (previously the check did not consider underscores whatsoever for gders with single characters in their names).

Also filtered empty possessors out (happens when there is no possessor)