### PR TITLE
Various fixes and cleanup

### DIFF
--- a/MapsetVerifier.Checks/Catch/Compose/Platter/CheckPlatterHigherSnappedHyperdash.cs
+++ b/MapsetVerifier.Checks/Catch/Compose/Platter/CheckPlatterHigherSnappedHyperdash.cs
@@ -81,8 +81,9 @@ public class CheckPlatterHigherSnappedHyperdash : BeatmapCheck
                 // Additional check based on BPM scaling if we moved a lot of x distance
                 // With 180 BPM allow 10 pixels of room
                 var distanceToFollowUp = (int)Math.Abs(next.Position.X - followUp.Position.X);
-                var followUpScaledBpm = beatmap.GetScaledBpm(followUp);
-                var allowedAntiflowDistance = (int)Math.Floor(10 * followUpScaledBpm);
+                var timeBetweenMs = (int)(followUp.Time - next.Time);
+                var timeBasedFactor = timeBetweenMs / 50.0;
+                var allowedAntiflowDistance = (int)Math.Floor(10 * timeBasedFactor);
 
                 if (distanceToFollowUp <= allowedAntiflowDistance)
                 {

--- a/MapsetVerifier.Server/Model/ApiBeatmapInfo.cs
+++ b/MapsetVerifier.Server/Model/ApiBeatmapInfo.cs
@@ -4,11 +4,13 @@ public readonly struct ApiBeatmapInfo(
     string? title,
     string? artist,
     string? creator,
+    ulong? beatmapId,
     ulong? beatmapSetId
 )
 {
     public string? Title { get; } = title;
     public string? Artist { get; } = artist;
     public string? Creator { get; } = creator;
+    public ulong? BeatmapId { get; } = beatmapId;
     public ulong? BeatmapSetId { get; } = beatmapSetId;
 }

--- a/MapsetVerifier.Server/Service/BeatmapService.cs
+++ b/MapsetVerifier.Server/Service/BeatmapService.cs
@@ -150,6 +150,10 @@ public static class BeatmapService
         var content = File.ReadAllText(osuFile);
         var meta = ParseBeatmapMetadata(beatmapSetFolder, content);
 
+        ulong? beatmapId = null;
+        if (ulong.TryParse(meta.beatmapId, out var parsedBeatmapId))
+            beatmapId = parsedBeatmapId;
+
         ulong? beatmapSetId = null;
         if (ulong.TryParse(meta.beatmapSetId, out var parsedBeatmapSetId))
             beatmapSetId = parsedBeatmapSetId;
@@ -158,6 +162,7 @@ public static class BeatmapService
             title: meta.title,
             artist: meta.artist,
             creator: meta.creator,
+            beatmapId: beatmapId,
             beatmapSetId: beatmapSetId
         );
     }

--- a/electron-app/src/Types.ts
+++ b/electron-app/src/Types.ts
@@ -58,6 +58,7 @@ export type ApiBeatmapInfo = {
   title: string | null;
   artist: string | null;
   creator: string | null;
+  beatmapId: number | null;
   beatmapSetId: number | null;
 };
 

--- a/electron-app/src/components/beatmaps/BeatmapSelectionNavigator.tsx
+++ b/electron-app/src/components/beatmaps/BeatmapSelectionNavigator.tsx
@@ -37,12 +37,7 @@ export default function BeatmapSelectionNavigator() {
     if (!shouldNavigateToChecks(location.pathname, settings.goToChecksOnMapsetSwitch)) return;
 
     navigate('/checks', { viewTransition: true });
-  }, [
-    beatmapFolderPath,
-    location.pathname,
-    navigate,
-    settings.goToChecksOnMapsetSwitch,
-  ]);
+  }, [beatmapFolderPath, location.pathname, navigate, settings.goToChecksOnMapsetSwitch]);
 
   return null;
 }

--- a/electron-app/src/components/checks/BeatmapActionButtons.tsx
+++ b/electron-app/src/components/checks/BeatmapActionButtons.tsx
@@ -1,5 +1,12 @@
 ﻿import { Button, Group, Tooltip, useMantineTheme } from '@mantine/core';
-import { IconFolder, IconMessage, IconRefresh, IconVersions, IconWorld } from '@tabler/icons-react';
+import {
+  IconFolder,
+  IconLink,
+  IconMessage,
+  IconRefresh,
+  IconVersions,
+  IconWorld,
+} from '@tabler/icons-react';
 import { useOpenExternal } from '../../hooks/useOpenExternal.ts';
 
 export type SnapshotFolderTarget = {
@@ -10,6 +17,7 @@ export type SnapshotFolderTarget = {
 interface BeatmapActionButtonsProps {
   beatmapFolderPath?: string;
   beatmapSetId?: number;
+  beatmapId?: number;
   onReparse: () => Promise<void>;
   /** Undefined hides the button; null disables it on the snapshots page. */
   snapshotFolder?: SnapshotFolderTarget | null;
@@ -23,6 +31,7 @@ async function openFolderPath(folderPath: string) {
 function BeatmapActionButtons({
   beatmapFolderPath,
   beatmapSetId,
+  beatmapId,
   onReparse,
   snapshotFolder,
 }: BeatmapActionButtonsProps) {
@@ -116,6 +125,25 @@ function BeatmapActionButtons({
           disabled={!beatmapSetId}
         >
           <IconMessage />
+        </Button>
+      </Tooltip>
+      <Tooltip label="Open with osu!direct">
+        <Button
+          size="xs"
+          variant="default"
+          type="button"
+          onClick={async () => {
+            if (!beatmapId) return;
+            try {
+              await openExternal(`osu://b/${beatmapId}`);
+            } catch (e) {
+              console.error('Failed to open via osu direct:', e);
+              alert('Failed to open via osu!direct. See console for details.');
+            }
+          }}
+          disabled={!beatmapId}
+        >
+          <IconLink />
         </Button>
       </Tooltip>
     </Group>

--- a/electron-app/src/components/checks/Checks.tsx
+++ b/electron-app/src/components/checks/Checks.tsx
@@ -93,31 +93,6 @@ function Checks() {
     : undefined;
   const currentOverrideLevel = displayedCategory ? getOverrideLevel(displayedCategory) : undefined;
 
-  useEffect(() => {
-    if (difficultiesForTabs.length === 0) return;
-
-    const nextCategory = selectedCategory ?? 'General';
-    const categoryExists =
-      nextCategory === 'General' ||
-      difficultiesForTabs.some((difficulty) => difficulty.category === nextCategory);
-
-    if (!categoryExists) {
-      setSelectedCategory('General');
-      setDisplayedCategory('General');
-      setIsDifficultyContentVisible(true);
-      return;
-    }
-
-    if (!data) return;
-
-    if (displayedCategory === nextCategory) {
-      setIsDifficultyContentVisible(true);
-      return;
-    }
-
-    setIsDifficultyContentVisible(false);
-  }, [data, difficultiesForTabs, selectedCategory, displayedCategory]);
-
   const handleDifficultyContentTransitionEnd = React.useCallback(() => {
     if (isDifficultyContentVisible) return;
 
@@ -191,6 +166,31 @@ function Checks() {
   const selectedGroup =
     groupedDifficulties.find((g) => g.mode === selectedMode) ?? groupedDifficulties[0];
 
+  useEffect(() => {
+    if (difficultiesForTabs.length === 0) return;
+
+    const nextCategory = selectedCategory ?? 'General';
+    const categoryExists =
+      nextCategory === 'General' ||
+      difficultiesForTabs.some((difficulty) => difficulty.category === nextCategory);
+
+    if (!categoryExists) {
+      setSelectedCategory('General');
+      setDisplayedCategory('General');
+      setIsDifficultyContentVisible(true);
+      return;
+    }
+
+    if (!data) return;
+
+    if (displayedCategory === nextCategory) {
+      setIsDifficultyContentVisible(true);
+      return;
+    }
+
+    setIsDifficultyContentVisible(false);
+  }, [data, difficultiesForTabs, selectedCategory, displayedCategory]);
+
   if (!folder) {
     return (
       <Alert
@@ -252,7 +252,7 @@ function Checks() {
             onHover={(id) =>
               setHoveredDifficulty(
                 id && id !== GENERAL_TAB_ID
-                  ? selectedGroup.difficulties.find((d) => d.category === id)
+                  ? difficultiesForTabs.find((d) => d.category === id)
                   : undefined
               )
             }

--- a/electron-app/src/components/checks/Checks.tsx
+++ b/electron-app/src/components/checks/Checks.tsx
@@ -46,12 +46,12 @@ function Checks() {
     }
   }, [folder]);
 
-  const { data, isLoading, isError, error, beatmapFolderPath, progress, structure } =
+  const { data, isLoading, isFetching, isError, error, beatmapFolderPath, progress, structure } =
     useBeatmapChecks({
       folder,
       songFolder: settings.songFolder,
     });
-  const areCheckResultsExpanded = !!data && !isLoading;
+  const areCheckResultsExpanded = !!data && !isLoading && !isFetching;
   const levelIconsLoading = isLoading;
 
   const { bgUrl } = useBeatmapBackground(folder, settings.songFolder);
@@ -277,9 +277,9 @@ function Checks() {
           {error?.stackTrace && <StackTraceMessage stackTrace={error.stackTrace} />}
         </Alert>
       )}
-      {(isLoading || data) && (
+      {(isLoading || isFetching || data) && (
         <Flex gap="sm" p="md" direction="column" bg="dark.6">
-          {isLoading && (
+          {(isLoading || isFetching) && (
             <ChecksResults
               isLoading
               isError={false}

--- a/electron-app/src/components/checks/Checks.tsx
+++ b/electron-app/src/components/checks/Checks.tsx
@@ -223,6 +223,7 @@ function Checks() {
         <Group gap="sm">
           <BeatmapActionButtons
             beatmapFolderPath={beatmapFolderPath}
+            beatmapId={beatmapInfo?.beatmapId ?? undefined}
             beatmapSetId={beatmapInfo?.beatmapSetId ?? undefined}
             onReparse={triggerReparse}
           />

--- a/electron-app/src/components/checks/Checks.tsx
+++ b/electron-app/src/components/checks/Checks.tsx
@@ -296,7 +296,7 @@ function Checks() {
             animateOpacity
           >
             {data && (
-              <>
+              <Group gap="sm">
                 <DifficultyInfo
                   hoveredDifficulty={hoveredDifficulty}
                   selectedCategory={selectedCategory}
@@ -334,7 +334,7 @@ function Checks() {
                     overrideResult={displayedOverrideResult}
                   />
                 </Collapse>
-              </>
+              </Group>
             )}
           </Collapse>
         </Flex>

--- a/electron-app/src/components/common/DifficultyTabSelector.tsx
+++ b/electron-app/src/components/common/DifficultyTabSelector.tsx
@@ -67,7 +67,7 @@ function DifficultyTabSelector({
     : tabs;
 
   const isGeneralActive =
-    selectedId === GENERAL_TAB_ID || (highlightGeneralWhenIdle && hoveredId === undefined);
+    selectedId === GENERAL_TAB_ID || (highlightGeneralWhenIdle && hoveredId === undefined && !selectedId);
 
   const handleHover = (id: string | undefined) => {
     onHover?.(id);

--- a/electron-app/src/components/common/DifficultyTabSelector.tsx
+++ b/electron-app/src/components/common/DifficultyTabSelector.tsx
@@ -67,7 +67,8 @@ function DifficultyTabSelector({
     : tabs;
 
   const isGeneralActive =
-    selectedId === GENERAL_TAB_ID || (highlightGeneralWhenIdle && hoveredId === undefined && !selectedId);
+    selectedId === GENERAL_TAB_ID ||
+    (highlightGeneralWhenIdle && hoveredId === undefined && !selectedId);
 
   const handleHover = (id: string | undefined) => {
     onHover?.(id);

--- a/electron-app/src/components/documentation/BeatmapChecks.tsx
+++ b/electron-app/src/components/documentation/BeatmapChecks.tsx
@@ -1,9 +1,9 @@
-﻿import {Alert, Group, Loader, Text} from '@mantine/core';
+﻿import { Alert, Group, Loader, Text } from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
 import DocumentationCheck from './DocumentationCheck';
 import { useBeatmapDocumentationChecks } from './hooks/useDocumentationChecks';
 import { Mode } from '../../Types.ts';
 import { formatGameModeLabel } from '../../utils/gameMode';
-import {IconAlertCircle} from "@tabler/icons-react";
 
 interface BeatmapChecksProps {
   mode: Mode;

--- a/electron-app/src/components/documentation/BeatmapChecks.tsx
+++ b/electron-app/src/components/documentation/BeatmapChecks.tsx
@@ -1,8 +1,9 @@
-﻿import { Group, Text } from '@mantine/core';
+﻿import {Alert, Group, Loader, Text} from '@mantine/core';
 import DocumentationCheck from './DocumentationCheck';
 import { useBeatmapDocumentationChecks } from './hooks/useDocumentationChecks';
 import { Mode } from '../../Types.ts';
 import { formatGameModeLabel } from '../../utils/gameMode';
+import {IconAlertCircle} from "@tabler/icons-react";
 
 interface BeatmapChecksProps {
   mode: Mode;
@@ -11,8 +12,14 @@ interface BeatmapChecksProps {
 function BeatmapChecks({ mode }: BeatmapChecksProps) {
   const { checks, isLoading, isError } = useBeatmapDocumentationChecks(mode);
 
-  if (isLoading) return <Text>Loading...</Text>;
-  if (isError) return <Text>Error loading checks.</Text>;
+  if (isLoading) return <Loader size="sm" />;
+  if (isError) {
+    return (
+      <Alert icon={<IconAlertCircle />} color="red">
+        Failed to load {formatGameModeLabel(mode)} checks.
+      </Alert>
+    );
+  }
   if (!checks || checks.length === 0)
     return <Text>No {formatGameModeLabel(mode)} checks found.</Text>;
 

--- a/electron-app/src/components/overview/Overview.tsx
+++ b/electron-app/src/components/overview/Overview.tsx
@@ -50,6 +50,7 @@ function Overview() {
         <Group gap="sm" justify="space-between" style={{ width: '100%' }}>
           <BeatmapActionButtons
             beatmapFolderPath={beatmapFolderPath}
+            beatmapId={beatmapInfo?.beatmapId ?? undefined}
             beatmapSetId={beatmapInfo?.beatmapSetId ?? undefined}
             onReparse={triggerReparse}
           />

--- a/electron-app/src/components/overview/objects/components/ObjectsTimelineComparison.tsx
+++ b/electron-app/src/components/overview/objects/components/ObjectsTimelineComparison.tsx
@@ -1,4 +1,14 @@
-import { Box, Group, Paper, SegmentedControl, Stack, Switch, Text, Title, Tooltip } from '@mantine/core';
+import {
+  Box,
+  Group,
+  Paper,
+  SegmentedControl,
+  Stack,
+  Switch,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
 import { useEffect, useMemo, useState } from 'react';
 import HitsoundStripLegend from './HitsoundStripLegend.tsx';
 import ObjectsTimelineComparisonContent from './ObjectsTimelineComparisonContent.tsx';

--- a/electron-app/src/components/overview/objects/components/ObjectsTimelineHelpModal.tsx
+++ b/electron-app/src/components/overview/objects/components/ObjectsTimelineHelpModal.tsx
@@ -47,8 +47,8 @@ export default function ObjectsTimelineHelpModal({
             <Stack gap="xs">
               <Title order={5}>Hitsounding view</Title>
               <Text size="sm" c="dimmed">
-                Available for osu! and osu!catch. Switch with the Structure / Hitsounding control
-                in the timeline header.
+                Available for osu! and osu!catch. Switch with the Structure / Hitsounding control in
+                the timeline header.
               </Text>
               <List size="sm" spacing={4}>
                 <List.Item>

--- a/electron-app/src/components/snapshots/Snapshots.tsx
+++ b/electron-app/src/components/snapshots/Snapshots.tsx
@@ -159,6 +159,7 @@ function Snapshots() {
         <Group gap="sm">
           <BeatmapActionButtons
             beatmapFolderPath={beatmapFolderPath}
+            beatmapId={beatmapInfo?.beatmapId ?? undefined}
             beatmapSetId={beatmapInfo?.beatmapSetId ?? undefined}
             onReparse={triggerReparse}
             snapshotFolder={snapshotFolder}


### PR DESCRIPTION
1. Add support for an osu!direct link in the action bar (if beatmapId is set)
2. Reparsing now triggers the loading animation to give better feedback
3. Documentation error and loading have been made consistent in all tabs
4. Fix osu!catch check for antiflow to be time based instead of bpm based
5. Fix visual bug with hovering over difficulties in the checks page when in a different gamemode