### PR TITLE
Fix an issue where x127 Long Ver. is not seen as a stylized marker

### DIFF
--- a/MapsetVerifier.Checks.Tests/AllModes/Metadata/CheckTitleMarkersTests.cs
+++ b/MapsetVerifier.Checks.Tests/AllModes/Metadata/CheckTitleMarkersTests.cs
@@ -218,12 +218,12 @@ public class CheckTitleMarkersTests
         );
     }
 
-    [Fact]
-    public void SkipsStylisedLongParenthetical()
+    [Theory]
+    [InlineData("Pippiquest (Pippi x Mocha Romantic Movie Remix Edition)")]
+    [InlineData("You Make My Life 1UP (x127 Long Ver.)")]
+    public void SkipsStylisedLongParenthetical(string title)
     {
-        using var context = CreateContext(
-            "Pippiquest (Pippi x Mocha Romantic Movie Remix Edition)"
-        );
+        using var context = CreateContext(title);
 
         var issues = context.RunGeneralCheck<CheckTitleMarkers>();
 

--- a/MapsetVerifier.Checks/AllModes/General/Metadata/CheckTitleMarkers.cs
+++ b/MapsetVerifier.Checks/AllModes/General/Metadata/CheckTitleMarkers.cs
@@ -169,7 +169,7 @@ namespace MapsetVerifier.Checks.AllModes.General.Metadata
                         "field",
                         "title marker"
                     ).WithCause(
-                        @"Length or version markers not covered by the standard list should use a descriptive ""(#### Ver.)"" form in title case, e.g. ""(Extended Version)"" -> ""(Extended Ver.)"", ""(Long)"" -> ""(Long Ver.)""."
+                        @"Length or version markers not covered by the standard list should use a descriptive ""(#### Ver.)"" form in title case, e.g. ""(Extended Version)"" -> ""(Extended Ver.)"", ""(Long)"" -> ""(Long Ver.)"". Stylised markers considered part of the title should be kept as-is."
                     )
                 },
                 {
@@ -803,10 +803,15 @@ namespace MapsetVerifier.Checks.AllModes.General.Metadata
             return string.Join(
                 ' ',
                 words.Select(word =>
-                    CultureInfo.InvariantCulture.TextInfo.ToTitleCase(word.ToLowerInvariant())
+                    ContainsLetterAndDigit(word)
+                        ? word
+                        : CultureInfo.InvariantCulture.TextInfo.ToTitleCase(word.ToLowerInvariant())
                 )
             );
         }
+
+        private static bool ContainsLetterAndDigit(string text) =>
+            text.Any(char.IsLetter) && text.Any(char.IsDigit);
 
         private static string Capitalize(string str) =>
             str.Length == 0 ? str : char.ToUpper(str[0]) + str[1..];


### PR DESCRIPTION
Fixes incorrect warning
<img width="892" height="143" alt="image" src="https://github.com/user-attachments/assets/dbf9e3f3-d719-4470-883f-e58ac0994dee" />
