### PR TITLE
Adjusted snapshotting to be called when running checks as well

### DIFF
--- a/MapsetVerifier.Server/Service/BeatmapService.cs
+++ b/MapsetVerifier.Server/Service/BeatmapService.cs
@@ -4,11 +4,11 @@ using MapsetVerifier.Framework.Objects;
 using MapsetVerifier.Parser.Objects;
 using MapsetVerifier.Server.Model;
 using MapsetVerifier.Server.Service.OsuRuntime;
+using Serilog;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Processing;
-using Serilog;
 
 namespace MapsetVerifier.Server.Service;
 

--- a/MapsetVerifier.Server/Service/BeatmapService.cs
+++ b/MapsetVerifier.Server/Service/BeatmapService.cs
@@ -8,6 +8,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Processing;
+using Serilog;
 
 namespace MapsetVerifier.Server.Service;
 
@@ -364,6 +365,15 @@ public static class BeatmapService
         IProgress<CheckProgress>? progress = null
     )
     {
+        try
+        {
+            SnapshotService.SnapshotCurrentBeatmapSet(beatmapSet);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to snapshot beatmap set before running checks.");
+        }
+
         var issues = Checker.GetBeatmapSetIssues(beatmapSet, progress);
         return BuildBeatmapSetCheckResult(beatmapSet, issues);
     }

--- a/MapsetVerifier.Server/Service/SnapshotService.cs
+++ b/MapsetVerifier.Server/Service/SnapshotService.cs
@@ -7,6 +7,15 @@ namespace MapsetVerifier.Server.Service;
 
 public static class SnapshotService
 {
+    public static void SnapshotCurrentBeatmapSet(BeatmapSet beatmapSet)
+    {
+        var refBeatmap = beatmapSet.Beatmaps.FirstOrDefault();
+        if (refBeatmap?.MetadataSettings.beatmapSetId == null)
+            return;
+
+        Snapshotter.SnapshotBeatmapSet(beatmapSet);
+    }
+
     public static ApiSnapshotResult GetSnapshots(string beatmapSetFolder)
     {
         var beatmapSet = new BeatmapSet(beatmapSetFolder);
@@ -50,7 +59,7 @@ public static class SnapshotService
         }
 
         // Snapshot the current beatmap before we start comparing with previous snapshots
-        Snapshotter.SnapshotBeatmapSet(beatmapSet);
+        SnapshotCurrentBeatmapSet(beatmapSet);
 
         // Get general/files snapshot history
         var refSnapshots = Snapshotter.GetSnapshots(beatmapSetId, "files").ToArray();


### PR DESCRIPTION
As requested in Discord, people would like to always have a snapshot available of a beatmap when they first run any checks for the set