### PR TITLE
cleanup snapshot commit list

### DIFF
--- a/electron-app/src/components/snapshots/SnapshotCommitList.tsx
+++ b/electron-app/src/components/snapshots/SnapshotCommitList.tsx
@@ -1,5 +1,4 @@
 ﻿import {
-  Box,
   Group,
   Stack,
   Text,
@@ -10,6 +9,7 @@
   ScrollArea,
   ActionIcon,
   Tooltip,
+  Box,
 } from '@mantine/core';
 import {
   IconGitCommit,
@@ -19,7 +19,6 @@ import {
   IconChevronLeft,
   IconChevronRight,
 } from '@tabler/icons-react';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { useEffect, useRef } from 'react';
 import { ApiSnapshotCommit } from '../../Types';
 
@@ -67,28 +66,16 @@ function SnapshotCommitList({
   const theme = useMantineTheme();
   const viewportRef = useRef<HTMLDivElement>(null);
 
-  // Find the current index of the selected commit
   const currentIndex = selectedCommitId
     ? commits.findIndex((commit) => commit.id === selectedCommitId)
     : -1;
-  const commitVirtualizer = useVirtualizer({
-    count: commits.length,
-    estimateSize: () => 153,
-    getItemKey: (index) => commits[index]?.id ?? index,
-    getScrollElement: () => viewportRef.current,
-    horizontal: true,
-    overscan: 4,
-  });
 
-  // Scroll to selected commit when it changes
   useEffect(() => {
-    if (currentIndex < 0) return;
+    if (!selectedCommitId) return;
 
-    commitVirtualizer.scrollToIndex(currentIndex, {
-      align: 'center',
-      behavior: 'smooth',
-    });
-  }, [commitVirtualizer, currentIndex]);
+    const el = viewportRef.current?.querySelector(`[data-commit-id="${selectedCommitId}"]`);
+    el?.scrollIntoView({ inline: 'center', block: 'nearest', behavior: 'smooth' });
+  }, [selectedCommitId]);
 
   const isPreviousDisabled = currentIndex <= 0;
   const isNextDisabled = currentIndex === -1 || currentIndex >= commits.length - 1;
@@ -130,117 +117,93 @@ function SnapshotCommitList({
       <ScrollArea
         p="xs"
         bg={theme.colors.dark[8]}
+        scrollbars="x"
+        type="auto"
         style={{ borderRadius: theme.radius.md, flex: 1 }}
         viewportRef={viewportRef}
       >
-        <Box
-          style={{
-            height: 78,
-            position: 'relative',
-            width: `${commitVirtualizer.getTotalSize()}px`,
-          }}
-        >
-          {commitVirtualizer.getVirtualItems().map((virtualCommit) => {
-            const commit = commits[virtualCommit.index];
-            if (!commit) return null;
-
-            const index = virtualCommit.index;
+        <Group gap="xs" wrap="nowrap" align="stretch">
+          {commits.map((commit, index) => {
             const isSelected = selectedCommitId === commit.id;
             const isFirst = index === 0;
 
             return (
-              <Box
-                key={virtualCommit.key}
-                data-index={virtualCommit.index}
-                ref={commitVirtualizer.measureElement}
+              <UnstyledButton
+                key={commit.id}
+                data-commit-id={commit.id}
+                onClick={() => onSelectCommit(commit.id)}
                 style={{
-                  left: 0,
-                  paddingRight: 'var(--mantine-spacing-xs)',
-                  position: 'absolute',
-                  top: 0,
-                  transform: `translateX(${virtualCommit.start}px)`,
+                  borderTop: `2px solid ${isSelected ? theme.colors.blue[6] : theme.colors.dark[5]}`,
+                  backgroundColor: isSelected ? theme.colors.dark[6] : theme.colors.dark[7],
+                  transition: 'all 0.15s ease',
+                  borderRadius: theme.radius.sm,
+                  flexShrink: 0,
                 }}
               >
-                <UnstyledButton
-                  onClick={() => onSelectCommit(commit.id)}
-                  style={{
-                    borderTop: `2px solid ${isSelected ? theme.colors.blue[6] : theme.colors.dark[5]}`,
-                    backgroundColor: isSelected ? theme.colors.dark[6] : theme.colors.dark[7],
-                    transition: 'all 0.15s ease',
-                    borderRadius: theme.radius.sm,
-                    width: '145px',
-                  }}
-                >
-                  <Box px="xs" py={6}>
-                    <Stack gap="sm">
-                      <Group gap={6} wrap="nowrap" align="center">
-                        <Tooltip label="Latest Snapshot" disabled={!isFirst}>
-                          <Box style={{ display: 'flex', flexShrink: 0 }}>
-                            <IconGitCommit
-                              size={15}
-                              color={isFirst ? theme.colors.green[5] : theme.colors.dark[3]}
-                              stroke={isFirst ? 3 : 2}
-                            />
-                          </Box>
-                        </Tooltip>
-                        <Group
-                          gap={4}
-                          wrap="nowrap"
-                          align="baseline"
-                          style={{ minWidth: 0, flex: 1 }}
+                <Box px="xs" py={6}>
+                  <Stack gap="sm">
+                    <Group gap={6} wrap="nowrap" align="center">
+                      <Tooltip label="Latest Snapshot" disabled={!isFirst}>
+                        <Box style={{ display: 'flex', flexShrink: 0 }}>
+                          <IconGitCommit
+                            size={15}
+                            color={isFirst ? theme.colors.green[5] : theme.colors.dark[3]}
+                            stroke={isFirst ? 3 : 2}
+                          />
+                        </Box>
+                      </Tooltip>
+                      <Group gap={4} wrap="nowrap" align="baseline">
+                        <Text size="xs" fw={500} lh={1.1}>
+                          {formatDate(commit.date)}
+                        </Text>
+                        <Text c="dimmed" fz="10px" lh={1.1} style={{ flexShrink: 0 }}>
+                          {formatTime(commit.date)}
+                        </Text>
+                      </Group>
+                    </Group>
+                    <Group gap={4} wrap="nowrap">
+                      {commit.totalChanges === 0 && (
+                        <Badge size="xs" variant="light" color="gray">
+                          No changes
+                        </Badge>
+                      )}
+                      {commit.additions > 0 && (
+                        <Badge
+                          size="xs"
+                          variant="light"
+                          color="green"
+                          leftSection={<IconPlus size={8} />}
                         >
-                          <Text size="xs" fw={500} lh={1.1} truncate>
-                            {formatDate(commit.date)}
-                          </Text>
-                          <Text c="dimmed" fz="10px" lh={1.1} style={{ flexShrink: 0 }}>
-                            {formatTime(commit.date)}
-                          </Text>
-                        </Group>
-                      </Group>
-                      <Group gap={4} wrap="nowrap">
-                        {commit.totalChanges === 0 && (
-                          <Badge size="xs" variant="light" color="gray">
-                            No changes
-                          </Badge>
-                        )}
-                        {commit.additions > 0 && (
-                          <Badge
-                            size="xs"
-                            variant="light"
-                            color="green"
-                            leftSection={<IconPlus size={8} />}
-                          >
-                            {commit.additions}
-                          </Badge>
-                        )}
-                        {commit.removals > 0 && (
-                          <Badge
-                            size="xs"
-                            variant="light"
-                            color="red"
-                            leftSection={<IconMinus size={8} />}
-                          >
-                            {commit.removals}
-                          </Badge>
-                        )}
-                        {commit.modifications > 0 && (
-                          <Badge
-                            size="xs"
-                            variant="light"
-                            color="yellow"
-                            leftSection={<IconArrowsExchange size={8} />}
-                          >
-                            {commit.modifications}
-                          </Badge>
-                        )}
-                      </Group>
-                    </Stack>
-                  </Box>
-                </UnstyledButton>
-              </Box>
+                          {commit.additions}
+                        </Badge>
+                      )}
+                      {commit.removals > 0 && (
+                        <Badge
+                          size="xs"
+                          variant="light"
+                          color="red"
+                          leftSection={<IconMinus size={8} />}
+                        >
+                          {commit.removals}
+                        </Badge>
+                      )}
+                      {commit.modifications > 0 && (
+                        <Badge
+                          size="xs"
+                          variant="light"
+                          color="yellow"
+                          leftSection={<IconArrowsExchange size={8} />}
+                        >
+                          {commit.modifications}
+                        </Badge>
+                      )}
+                    </Group>
+                  </Stack>
+                </Box>
+              </UnstyledButton>
             );
           })}
-        </Box>
+        </Group>
       </ScrollArea>
       <ActionIcon
         variant="default"


### PR DESCRIPTION
virtualizer introduced fixed widths and heights which made ux feel worse with truncated content and off-centered list, and since i highly doubt the commit list will ever get long enough to the point it needs to be virtualized, i decided to scrap it in favor of the more responsive ui