### PR TITLE
Only show pin on hover, selected, or bookmarked

### DIFF
--- a/electron-app/src/components/beatmaps/BeatmapCard.tsx
+++ b/electron-app/src/components/beatmaps/BeatmapCard.tsx
@@ -216,8 +216,8 @@ function BeatmapCard({
               top: 4,
               right: 4,
               zIndex: 3,
-              opacity: isHovered || isSelected ? 1 : 0,
-              pointerEvents: isHovered || isSelected ? 'auto' : 'none',
+              opacity: isHovered || isSelected || isBookmarked ? 1 : 0,
+              pointerEvents: isHovered || isSelected || isBookmarked ? 'auto' : 'none',
               transition: `opacity ${transitionMs}`,
             }}
             onClick={(e) => {

--- a/electron-app/src/components/beatmaps/BeatmapCard.tsx
+++ b/electron-app/src/components/beatmaps/BeatmapCard.tsx
@@ -211,7 +211,15 @@ function BeatmapCard({
             variant="subtle"
             color="yellow"
             size="sm"
-            style={{ position: 'absolute', top: 4, right: 4, zIndex: 3 }}
+            style={{
+              position: 'absolute',
+              top: 4,
+              right: 4,
+              zIndex: 3,
+              opacity: isHovered || isSelected ? 1 : 0,
+              pointerEvents: isHovered || isSelected ? 'auto' : 'none',
+              transition: `opacity ${transitionMs}`,
+            }}
             onClick={(e) => {
               e.stopPropagation();
               toggleBookmark();


### PR DESCRIPTION
reduces clutter quite a bit by not perma having pin icons everywhere, only showing them when relevantr

https://github.com/user-attachments/assets/effdd20c-fc92-40bf-ae91-3122bb183ef6

