### PR TITLE
Add check for score overflow

### DIFF
--- a/MapsetVerifier.Checks/AllModes/Settings/CheckScoreOverflow.cs
+++ b/MapsetVerifier.Checks/AllModes/Settings/CheckScoreOverflow.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+using MapsetVerifier.Framework.Objects;
+using MapsetVerifier.Framework.Objects.Attributes;
+using MapsetVerifier.Framework.Objects.Metadata;
+using MapsetVerifier.Parser.Difficulty;
+using MapsetVerifier.Parser.Objects;
+
+namespace MapsetVerifier.Checks.AllModes.Settings
+{
+    [Check]
+    public class CheckScoreOverflow : BeatmapCheck
+    {
+        public override CheckMetadata GetMetadata() =>
+            new BeatmapCheckMetadata
+            {
+                Modes =
+                [
+                    Beatmap.Mode.Standard,
+                    Beatmap.Mode.Taiko,
+                    Beatmap.Mode.Catch,
+                    // osu!mania ScoreV1 is capped at 1 million and cannot overflow
+                ],
+                Category = "Settings",
+                Message = "Score overflow.",
+                Author = "Hivie",
+
+                Documentation = new Dictionary<string, string>
+                {
+                    {
+                        "Purpose",
+                        @"
+                        Warning when a difficulty's maximum ScoreV1 (HDHRDTFL SS) exceeds the signed 32-bit integer limit."
+                    },
+                    {
+                        "Reasoning",
+                        @"
+                        Stable stores ScoreV1 as a signed 32-bit integer (max 2,147,483,647). If a perfect HD+HR+DT+FL play
+                        would exceed that, it would cause ScoreV2 mod to be automatically enabled for stable, therefore
+                        rendering the map unplayable. This mostly happens on long, high-combo maps.
+
+                        HD+HR+DT+FL is the highest ScoreV1 mod multiplier product available in osu!, osu!taiko, and osu!catch.
+
+                        To address this, a 'lazer-only' flag can be added to the map, which users can request the NAT to add
+                        prior to having the map nominated.
+
+                        osu!mania is excluded because its ScoreV1 is already capped at 1,000,000."
+                    },
+                },
+            };
+
+        public override Dictionary<string, IssueTemplate> GetTemplates() =>
+            new()
+            {
+                {
+                    "Overflow",
+                    new IssueTemplate(
+                        Issue.Level.Problem,
+                        "Score overflows in osu!(stable) ({0}). Ensure the map has the 'lazer-only' flag.",
+                        "overflowing score"
+                    ).WithCause(
+                        "The maximum ScoreV1 achievable with an HDHRDTFL SS exceeds the 32-bit integer limit (2,147,483,647)."
+                    )
+                },
+            };
+
+        public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
+        {
+            if (beatmap.HitObjects.Count == 0)
+                yield break;
+
+            long maxScore = LegacyScoreHelper.GetMaximumLegacyScore(beatmap);
+
+            if (maxScore <= int.MaxValue)
+                yield break;
+
+            yield return new Issue(
+                GetTemplate("Overflow"),
+                beatmap,
+                maxScore.ToString("N0", CultureInfo.InvariantCulture)
+            );
+        }
+    }
+}

--- a/MapsetVerifier.Parser/Difficulty/LegacyScoreHelper.cs
+++ b/MapsetVerifier.Parser/Difficulty/LegacyScoreHelper.cs
@@ -1,0 +1,62 @@
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring.Legacy;
+using Beatmap = MapsetVerifier.Parser.Objects.Beatmap;
+
+namespace MapsetVerifier.Parser.Difficulty;
+
+/// <summary>
+///     Computes maximum legacy (ScoreV1) scores using osu!'s legacy score simulators.
+/// </summary>
+public static class LegacyScoreHelper
+{
+    /// <summary>
+    ///     Returns the maximum ScoreV1 total achievable on an HDHRDTFL SS (including bonus score).
+    ///     Excludes osu!mania as it caps score at 1 million.-
+    /// </summary>
+    public static long GetMaximumLegacyScore(Beatmap mvBeatmap)
+    {
+        if (mvBeatmap.GeneralSettings.mode == Beatmap.Mode.Mania)
+            throw new ArgumentException(
+                "Legacy score overflow calculation does not apply to mania."
+            );
+
+        var workingBeatmap = new FlatWorkingBeatmap(
+            Path.Combine(mvBeatmap.SongPath, mvBeatmap.MapPath)
+        );
+        var ruleset = workingBeatmap.BeatmapInfo.Ruleset.CreateInstance();
+
+        if (ruleset is not ILegacyRuleset legacyRuleset)
+            throw new InvalidOperationException(
+                $"Ruleset {ruleset.RulesetInfo.ShortName} does not support legacy score simulation."
+            );
+
+        var mods = CreateMaxMultiplierMods(ruleset);
+        var playableBeatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
+        var simulator = legacyRuleset.CreateLegacyScoreSimulator();
+        var attributes = simulator.Simulate(workingBeatmap, playableBeatmap);
+        var difficulty = LegacyBeatmapConversionDifficultyInfo.FromBeatmap(workingBeatmap.Beatmap);
+        double modMultiplier = simulator.GetLegacyScoreMultiplier(mods, difficulty);
+
+        // ScoreV1 only applies the mod multiplier to the combo portion.
+        return attributes.AccuracyScore
+            + (long)Math.Round(attributes.ComboScore * modMultiplier)
+            + attributes.BonusScore;
+    }
+
+    private static Mod[] CreateMaxMultiplierMods(Ruleset ruleset)
+    {
+        var hidden = ruleset.CreateMod<ModHidden>();
+        var hardRock = ruleset.CreateMod<ModHardRock>();
+        var doubleTime = ruleset.CreateMod<ModDoubleTime>();
+        var flashlight = ruleset.CreateMod<ModFlashlight>();
+
+        if (hidden == null || hardRock == null || doubleTime == null || flashlight == null)
+            throw new InvalidOperationException(
+                $"Ruleset {ruleset.RulesetInfo.ShortName} is missing HD/HR/DT/FL mods required for max ScoreV1."
+            );
+
+        return [hidden, hardRock, doubleTime, flashlight];
+    }
+}


### PR DESCRIPTION
uses osu! to simulate a HDHRDTFL SS to get the max possible score on a map to check for signed 32-bit overflow.

I'm torn down between going with a warning or a problem with this: a problem has more visibility but this kinda makes more sense as a warning given we can't really check if this is "fixed", as it's more of a "pls ensure this is correct" thing. opinions appreciated.