### PR TITLE
Adjust strain calculations to match osu-tools

### DIFF
--- a/MapsetVerifier.Parser.Tests/Difficulty/SkillDifficultySourceTests.cs
+++ b/MapsetVerifier.Parser.Tests/Difficulty/SkillDifficultySourceTests.cs
@@ -1,3 +1,4 @@
+using MapsetVerifier.Parser.Difficulty;
 using MapsetVerifier.Parser.Objects;
 using osu.Game.Rulesets.Difficulty.Skills;
 using Xunit;
@@ -5,12 +6,11 @@ using Xunit;
 namespace MapsetVerifier.Parser.Tests.Difficulty;
 
 /// <summary>
-///     Canary for BeatmapAnalysisService's skill-sampling dispatch (GetSkillDifficultySamples):
-///     every skill must expose either GetCurrentStrainPeaks (StrainSkill/VariableLengthStrainSkill)
-///     or GetObjectDifficulties (all skills) so the overview charts have something to show. Rulesets
-///     have previously moved skills off StrainSkill (e.g. osu!std's Speed/Reading onto a
-///     HarmonicSkill base with no strain-peaks concept) without warning; this catches a future skill
-///     type that loses both.
+///     Canary for <see cref="SkillStrainTimeline" />: every skill must expose either section strain
+///     peaks (<see cref="StrainSkill" />) or per-object difficulties (all skills) so the overview
+///     charts have something to show. Rulesets have previously moved skills off
+///     <see cref="StrainSkill" /> (e.g. osu!std's Speed/Reading onto a HarmonicSkill base with no
+///     strain-peaks concept) without warning; this catches a future skill type that loses both.
 /// </summary>
 public class SkillDifficultySourceTests
 {
@@ -29,13 +29,13 @@ public class SkillDifficultySourceTests
 
         foreach (var skill in beatmap.Skills)
         {
-            var hasStrainPeaks = skill is StrainSkill or VariableLengthStrainSkill;
+            var hasStrainPeaks = skill is StrainSkill;
             var hasObjectDifficulties = skill.GetObjectDifficulties().Count > 0;
 
             Assert.True(
                 hasStrainPeaks || hasObjectDifficulties,
                 $"Skill {skill.GetType().FullName} exposes neither strain peaks nor object difficulties - "
-                    + "BeatmapAnalysisService.GetSkillDifficultySamples would silently show nothing for it."
+                    + "SkillStrainTimeline would silently show nothing for it."
             );
         }
     }

--- a/MapsetVerifier.Parser.Tests/Difficulty/SkillStrainTimelineTests.cs
+++ b/MapsetVerifier.Parser.Tests/Difficulty/SkillStrainTimelineTests.cs
@@ -1,0 +1,229 @@
+using System.Text;
+using MapsetVerifier.Parser.Difficulty;
+using MapsetVerifier.Parser.Objects;
+using Xunit;
+
+namespace MapsetVerifier.Parser.Tests.Difficulty;
+
+/// <summary>
+///     Regression cover for https://github.com/Naxesss/MapsetVerifier/issues/188 - strain charts that
+///     didn't match what lazer/PerformanceCalculatorGUI show. The map used here ramps up over time and
+///     has a long break in the middle, so a timeline that is ordered by value instead of time, that is
+///     truncated, or that holds the last note's difficulty through breaks all fail visibly.
+/// </summary>
+public class SkillStrainTimelineTests
+{
+    private const double BreakStartMs = 30_000;
+    private const double BreakEndMs = 45_000;
+    private const double LastObjectMs = 70_000;
+
+    [Theory]
+    [InlineData(Beatmap.Mode.Standard)]
+    [InlineData(Beatmap.Mode.Taiko)]
+    [InlineData(Beatmap.Mode.Catch)]
+    [InlineData(Beatmap.Mode.Mania)]
+    public void Timeline_IsChronologicalAndContiguous(Beatmap.Mode mode)
+    {
+        foreach (var (skill, intervals) in BuildTimelines(mode))
+        {
+            Assert.NotEmpty(intervals);
+
+            for (var index = 1; index < intervals.Count; index++)
+            {
+                Assert.True(
+                    intervals[index].StartTime >= intervals[index - 1].StartTime,
+                    $"{skill}: interval {index} starts at {intervals[index].StartTime}, before its "
+                        + $"predecessor at {intervals[index - 1].StartTime}. Strain peaks sorted by "
+                        + "value are being read as if they were a timeline."
+                );
+
+                Assert.Equal(intervals[index - 1].EndTime, intervals[index].StartTime, 3);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     osu!std's Aim (a <c>VariableLengthStrainSkill</c>) discards its lowest strain peaks once a
+    ///     map runs past ~44s, so reading them as a timeline used to make the chart stop dead partway
+    ///     through. Every skill's timeline must reach the end of the map.
+    /// </summary>
+    [Theory]
+    [InlineData(Beatmap.Mode.Standard)]
+    [InlineData(Beatmap.Mode.Taiko)]
+    [InlineData(Beatmap.Mode.Catch)]
+    [InlineData(Beatmap.Mode.Mania)]
+    public void Timeline_ReachesEndOfMap(Beatmap.Mode mode)
+    {
+        foreach (var (skill, intervals) in BuildTimelines(mode))
+            Assert.True(
+                intervals[^1].EndTime >= LastObjectMs,
+                $"{skill}: timeline ends at {intervals[^1].EndTime}ms but the map runs to {LastObjectMs}ms."
+            );
+    }
+
+    /// <summary>
+    ///     The sorted-peaks bug produced a timeline that started at the map's peak and only ever went
+    ///     down. Real difficulty rises and falls with the map; no skill should decay monotonically
+    ///     across one with a break and a dense second half in it.
+    /// </summary>
+    [Theory]
+    [InlineData(Beatmap.Mode.Standard)]
+    [InlineData(Beatmap.Mode.Taiko)]
+    [InlineData(Beatmap.Mode.Catch)]
+    [InlineData(Beatmap.Mode.Mania)]
+    public void Timeline_DoesNotDecayMonotonically(Beatmap.Mode mode)
+    {
+        foreach (var (skill, intervals) in BuildTimelines(mode))
+            Assert.True(
+                intervals.Zip(intervals.Skip(1)).Any(pair => pair.Second.Value > pair.First.Value),
+                $"{skill}: every interval is lower than the one before it - the timeline is ordered "
+                    + "by value, not by time."
+            );
+    }
+
+    /// <summary>
+    ///     osu!std is the mode the mismatch was reported against, and Aim the skill that regressed.
+    ///     The map's dense, jumpy half is at the end, so that is where every std skill should peak.
+    /// </summary>
+    [Fact]
+    public void StandardTimeline_PeaksInTheHarderSecondHalf()
+    {
+        foreach (var (skill, intervals) in BuildTimelines(Beatmap.Mode.Standard))
+        {
+            var peak = intervals.MaxBy(interval => interval.Value);
+
+            // The section straddling the break's end counts: skills that reward change legitimately
+            // spike on the transition into the dense section.
+            Assert.True(
+                peak.EndTime > BreakEndMs,
+                $"{skill}: peaks at {peak.StartTime}ms, in the sparse first half, even though the "
+                    + $"dense section starts at {BreakEndMs}ms."
+            );
+        }
+    }
+
+    [Theory]
+    [InlineData(Beatmap.Mode.Standard)]
+    [InlineData(Beatmap.Mode.Taiko)]
+    [InlineData(Beatmap.Mode.Catch)]
+    [InlineData(Beatmap.Mode.Mania)]
+    public void Timeline_ReadsZeroThroughBreaks(Beatmap.Mode mode)
+    {
+        // Only the per-object skills can express a break; section-based strain skills decay across
+        // one instead, which is the behaviour lazer itself shows.
+        foreach (var (skill, intervals) in BuildTimelines(mode))
+        {
+            if (intervals.All(interval => interval.Value > 0))
+                continue;
+
+            var midBreak = intervals.FirstOrDefault(interval =>
+                interval.StartTime <= (BreakStartMs + BreakEndMs) / 2
+                && interval.EndTime > (BreakStartMs + BreakEndMs) / 2
+            );
+
+            Assert.True(
+                midBreak.Value == 0,
+                $"{skill}: mid-break difficulty is {midBreak.Value}, not 0 - the last note before the "
+                    + "break is being held through it."
+            );
+        }
+    }
+
+    private static List<(string Skill, List<StrainInterval> Intervals)> BuildTimelines(
+        Beatmap.Mode mode
+    )
+    {
+        var beatmap = CreateBeatmap(mode);
+        beatmap.EnsureTimedAttributesCalculated();
+
+        Assert.NotEmpty(beatmap.Skills);
+        Assert.NotEmpty(beatmap.DifficultyObjectTimings);
+
+        return beatmap
+            .Skills.Select(skill =>
+                (
+                    SkillNameFormatter.GetSkillName(skill, beatmap),
+                    SkillStrainTimeline.Build(skill, beatmap)
+                )
+            )
+            .Where(entry => entry.Item2.Count > 0)
+            .ToList();
+    }
+
+    private static Beatmap CreateBeatmap(Beatmap.Mode mode)
+    {
+        var tempRoot = Path.Combine(
+            Path.GetTempPath(),
+            "MapsetVerifierTests",
+            Guid.NewGuid().ToString()
+        );
+        Directory.CreateDirectory(tempRoot);
+
+        const string mapPath = "Test.osu";
+        var osuCode = BuildOsu(mode);
+
+        File.WriteAllText(Path.Combine(tempRoot, mapPath), osuCode);
+
+        return new Beatmap(osuCode, tempRoot, mapPath);
+    }
+
+    private static string BuildOsu(Beatmap.Mode mode)
+    {
+        var builder = new StringBuilder(
+            string.Join(
+                "\n",
+                "osu file format v14",
+                "[General]",
+                "AudioFilename: audio.mp3",
+                "Mode: " + (int)mode,
+                "[Metadata]",
+                "Title:Title",
+                "Artist:Artist",
+                "Creator:Creator",
+                "Version:Diff",
+                "[Difficulty]",
+                "HPDrainRate:5",
+                "CircleSize:4",
+                "OverallDifficulty:8",
+                "ApproachRate:9",
+                "SliderMultiplier:1.4",
+                "SliderTickRate:1",
+                "[Events]",
+                $"2,{BreakStartMs},{BreakEndMs}",
+                "[TimingPoints]",
+                "0,250,4,2,1,50,1,0",
+                "[HitObjects]"
+            )
+        );
+
+        // Sparse, stationary and monotonous up to the break, then a dense section of alternating
+        // jumps and alternating taiko colours, so difficulty unambiguously belongs to the second
+        // half in every ruleset.
+        for (var time = 0d; time < BreakStartMs; time += 1000)
+            AppendCircle(builder, mode, time, index: 0);
+
+        for (var time = BreakEndMs; time <= LastObjectMs; time += 125)
+            AppendCircle(builder, mode, time, index: (int)(time / 125));
+
+        return builder.ToString();
+    }
+
+    private static void AppendCircle(
+        StringBuilder builder,
+        Beatmap.Mode mode,
+        double time,
+        int index
+    )
+    {
+        // In mania, x maps to the column; elsewhere it's a position, and alternating it creates the
+        // movement the aim/movement skills read.
+        var x =
+            mode == Beatmap.Mode.Mania ? (index % 4) * 128 + 64
+            : index % 2 == 0 ? 64
+            : 448;
+        // Clap makes a taiko note a kat, so alternating it gives taiko's Colour skill something to
+        // read; harmless in the other rulesets.
+        var hitSound = index % 2 == 0 ? 0 : 8;
+        builder.Append($"\n{x},192,{(int)time},1,{hitSound},0:0:0:0:");
+    }
+}

--- a/MapsetVerifier.Parser/Difficulty/DifficultyObjectTiming.cs
+++ b/MapsetVerifier.Parser/Difficulty/DifficultyObjectTiming.cs
@@ -1,0 +1,6 @@
+namespace MapsetVerifier.Parser.Difficulty;
+
+/// <summary>
+///     Timespan of a single <c>DifficultyHitObject</c> as the ruleset processed it, in map time.
+/// </summary>
+public readonly record struct DifficultyObjectTiming(double StartTime, double EndTime);

--- a/MapsetVerifier.Parser/Difficulty/DifficultyObjectTimingCapture.cs
+++ b/MapsetVerifier.Parser/Difficulty/DifficultyObjectTimingCapture.cs
@@ -1,0 +1,26 @@
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using Beatmap = MapsetVerifier.Parser.Objects.Beatmap;
+
+namespace MapsetVerifier.Parser.Difficulty;
+
+/// <summary>
+///     Shared by the <c>Extended*DifficultyCalculator</c>s. Rulesets skip, merge and reorder objects
+///     before scoring them, so the only way to know which map times a skill's per-object difficulties
+///     belong to is to record the objects at the point the calculator is about to process them.
+/// </summary>
+internal static class DifficultyObjectTimingCapture
+{
+    public static List<DifficultyHitObject> Capture(
+        IEnumerable<DifficultyHitObject> sortedObjects,
+        Beatmap mvBeatmap
+    )
+    {
+        var objects = sortedObjects.ToList();
+
+        mvBeatmap.DifficultyObjectTimings = objects
+            .Select(hitObject => new DifficultyObjectTiming(hitObject.StartTime, hitObject.EndTime))
+            .ToList();
+
+        return objects;
+    }
+}

--- a/MapsetVerifier.Parser/Difficulty/ExtendedCatchDifficultyCalculator.cs
+++ b/MapsetVerifier.Parser/Difficulty/ExtendedCatchDifficultyCalculator.cs
@@ -2,6 +2,7 @@
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch.Difficulty;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using Beatmap = MapsetVerifier.Parser.Objects.Beatmap;
@@ -27,4 +28,8 @@ public class ExtendedCatchDifficultyCalculator(
         mvBeatmap.Skills = skills;
         return base.CreateDifficultyAttributes(beatmap, mods, mvBeatmap.Skills);
     }
+
+    protected override IEnumerable<DifficultyHitObject> SortObjects(
+        IEnumerable<DifficultyHitObject> input
+    ) => DifficultyObjectTimingCapture.Capture(base.SortObjects(input), mvBeatmap);
 }

--- a/MapsetVerifier.Parser/Difficulty/ExtendedManiaDifficultyCalculator.cs
+++ b/MapsetVerifier.Parser/Difficulty/ExtendedManiaDifficultyCalculator.cs
@@ -1,6 +1,7 @@
 ﻿using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mania.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -27,4 +28,8 @@ public class ExtendedManiaDifficultyCalculator(
         mvBeatmap.Skills = skills;
         return base.CreateDifficultyAttributes(beatmap, mods, mvBeatmap.Skills);
     }
+
+    protected override IEnumerable<DifficultyHitObject> SortObjects(
+        IEnumerable<DifficultyHitObject> input
+    ) => DifficultyObjectTimingCapture.Capture(base.SortObjects(input), mvBeatmap);
 }

--- a/MapsetVerifier.Parser/Difficulty/ExtendedOsuDifficultyCalculator.cs
+++ b/MapsetVerifier.Parser/Difficulty/ExtendedOsuDifficultyCalculator.cs
@@ -1,6 +1,7 @@
 ﻿using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty;
@@ -27,4 +28,8 @@ public class ExtendedOsuDifficultyCalculator(
         mvBeatmap.Skills = skills;
         return base.CreateDifficultyAttributes(beatmap, mods, mvBeatmap.Skills);
     }
+
+    protected override IEnumerable<DifficultyHitObject> SortObjects(
+        IEnumerable<DifficultyHitObject> input
+    ) => DifficultyObjectTimingCapture.Capture(base.SortObjects(input), mvBeatmap);
 }

--- a/MapsetVerifier.Parser/Difficulty/ExtendedTaikoDifficultyCalculator.cs
+++ b/MapsetVerifier.Parser/Difficulty/ExtendedTaikoDifficultyCalculator.cs
@@ -1,6 +1,7 @@
 ﻿using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Difficulty;
@@ -27,4 +28,8 @@ public class ExtendedTaikoDifficultyCalculator(
         mvBeatmap.Skills = skills;
         return base.CreateDifficultyAttributes(beatmap, mods, mvBeatmap.Skills);
     }
+
+    protected override IEnumerable<DifficultyHitObject> SortObjects(
+        IEnumerable<DifficultyHitObject> input
+    ) => DifficultyObjectTimingCapture.Capture(base.SortObjects(input), mvBeatmap);
 }

--- a/MapsetVerifier.Parser/Difficulty/SkillStrainTimeline.cs
+++ b/MapsetVerifier.Parser/Difficulty/SkillStrainTimeline.cs
@@ -1,0 +1,123 @@
+using System.Reflection;
+using MapsetVerifier.Parser.Objects;
+using osu.Game.Rulesets.Difficulty.Skills;
+
+namespace MapsetVerifier.Parser.Difficulty;
+
+/// <summary>
+///     Turns a processed <see cref="Skill" /> into a chronological difficulty-over-time timeline.
+///     <para>
+///         Mirrors how osu! itself charts strain (<c>osu-tools</c>'
+///         <a href="https://github.com/ppy/osu-tools/blob/master/PerformanceCalculatorGUI/Screens/Simulate/StrainVisualizer.cs">
+///             <c>StrainVisualizer</c>
+///         </a>
+///         ), so the overview charts line up with what PerformanceCalculatorGUI/lazer show:
+///         <see cref="StrainSkill" />s are charted from their section strain peaks, and every other
+///         skill type from its per-object difficulties anchored to the objects' own times.
+///     </para>
+/// </summary>
+public static class SkillStrainTimeline
+{
+    /// <summary>
+    ///     <see cref="StrainSkill.SectionLength" /> is protected, and rulesets override it
+    ///     (osu!catch's Movement uses 750ms). Falls back to osu!'s own default.
+    /// </summary>
+    private const int DefaultSectionLength = 400;
+
+    private static readonly PropertyInfo? SectionLengthProperty = typeof(StrainSkill).GetProperty(
+        "SectionLength",
+        BindingFlags.Instance | BindingFlags.NonPublic
+    );
+
+    public static List<StrainInterval> Build(Skill skill, Beatmap beatmap) =>
+        skill switch
+        {
+            // Note the deliberate absence of a VariableLengthStrainSkill case (osu!std's Aim).
+            // Its GetCurrentStrainPeaks() is not a timeline: peaks are inserted sorted by value
+            // (highest first) and the lowest ones are discarded once the map exceeds ~44s, since
+            // the class only ever intends them to be fed into a weighted sum. Reading it as a
+            // timeline produces a graph that starts at the map's peak, decays monotonically, and
+            // falls off a cliff around 0:45. It goes through the per-object path instead, which is
+            // also what osu-tools does with it.
+            StrainSkill strainSkill => BuildFromStrainPeaks(strainSkill, beatmap),
+            _ => BuildFromObjectDifficulties(skill, beatmap),
+        };
+
+    /// <summary>
+    ///     <see cref="StrainSkill" /> divides the map into fixed <c>SectionLength</c> sections and keeps
+    ///     the highest strain in each. The first section ends at the first processed object's time
+    ///     rounded up to a section boundary (see <c>StrainSkill.ProcessInternal</c>), and each
+    ///     subsequent peak covers one section after that.
+    /// </summary>
+    private static List<StrainInterval> BuildFromStrainPeaks(StrainSkill skill, Beatmap beatmap)
+    {
+        var peaks = skill.GetCurrentStrainPeaks().ToList();
+        if (peaks.Count == 0)
+            return [];
+
+        var sectionLength = GetSectionLength(skill);
+        var firstSectionEnd =
+            Math.Ceiling(GetFirstProcessedObjectTime(beatmap) / sectionLength) * sectionLength;
+
+        var intervals = new List<StrainInterval>(peaks.Count);
+
+        for (var index = 0; index < peaks.Count; index++)
+        {
+            var end = firstSectionEnd + index * sectionLength;
+            intervals.Add(new StrainInterval(end - sectionLength, end, peaks[index]));
+        }
+
+        return intervals;
+    }
+
+    /// <summary>
+    ///     Per-object difficulties are index-aligned with the objects the ruleset processed, so each
+    ///     one covers its own object. A value is held for up to one section length past the object's
+    ///     end (matching how strain sections linger), then drops to zero until the next object - which
+    ///     is what makes breaks read as zero difficulty instead of holding the last note's value.
+    /// </summary>
+    private static List<StrainInterval> BuildFromObjectDifficulties(Skill skill, Beatmap beatmap)
+    {
+        var difficulties = skill.GetObjectDifficulties();
+        var timings = beatmap.DifficultyObjectTimings;
+
+        var count = Math.Min(difficulties.Count, timings.Count);
+        if (count == 0)
+            return [];
+
+        var intervals = new List<StrainInterval>(count);
+
+        for (var index = 0; index < count; index++)
+        {
+            var timing = timings[index];
+            var start = timing.StartTime;
+            var end = timing.EndTime + DefaultSectionLength;
+
+            // Objects can overlap (2B, catch juice streams); never let one interval run into the next.
+            var nextStart = index + 1 < count ? timings[index + 1].StartTime : (double?)null;
+            if (nextStart.HasValue)
+                end = Math.Min(end, nextStart.Value);
+
+            end = Math.Max(end, start);
+            intervals.Add(new StrainInterval(start, end, difficulties[index]));
+
+            if (nextStart.HasValue && nextStart.Value > end)
+                intervals.Add(new StrainInterval(end, nextStart.Value, 0));
+        }
+
+        return intervals;
+    }
+
+    private static double GetFirstProcessedObjectTime(Beatmap beatmap)
+    {
+        if (beatmap.DifficultyObjectTimings.Count > 0)
+            return beatmap.DifficultyObjectTimings[0].StartTime;
+
+        return beatmap.HitObjects.Count > 0
+            ? beatmap.HitObjects.Min(hitObject => hitObject.time)
+            : 0;
+    }
+
+    private static int GetSectionLength(StrainSkill skill) =>
+        SectionLengthProperty?.GetValue(skill) as int? ?? DefaultSectionLength;
+}

--- a/MapsetVerifier.Parser/Difficulty/StrainInterval.cs
+++ b/MapsetVerifier.Parser/Difficulty/StrainInterval.cs
@@ -1,0 +1,11 @@
+namespace MapsetVerifier.Parser.Difficulty;
+
+/// <summary>
+///     A skill's difficulty over one span of map time. Intervals are contiguous and chronological;
+///     gaps the skill contributes nothing to (breaks, spinner sections) are present as explicit
+///     zero-valued intervals rather than being left out.
+/// </summary>
+public readonly record struct StrainInterval(double StartTime, double EndTime, double Value)
+{
+    public double Length => EndTime - StartTime;
+}

--- a/MapsetVerifier.Parser/Objects/Beatmap.cs
+++ b/MapsetVerifier.Parser/Objects/Beatmap.cs
@@ -230,6 +230,14 @@ namespace MapsetVerifier.Parser.Objects
 
         public Skill[] Skills { get; set; } = [];
 
+        /// <summary>
+        ///     Start/end times of the <c>DifficultyHitObject</c>s the ruleset actually processed, in
+        ///     processing order. Rulesets skip and reorder objects (and merge/split them, e.g. catch),
+        ///     so this is the only reliable way to anchor a skill's per-object difficulties - which are
+        ///     index-aligned with this list, see <c>Skill.GetObjectDifficulties</c> - to a timeline.
+        /// </summary>
+        public IReadOnlyList<DifficultyObjectTiming> DifficultyObjectTimings { get; set; } = [];
+
         // Settings
         public GeneralSettings GeneralSettings { get; }
         public MetadataSettings MetadataSettings { get; }

--- a/MapsetVerifier.Server/Service/BeatmapAnalysisService.cs
+++ b/MapsetVerifier.Server/Service/BeatmapAnalysisService.cs
@@ -18,7 +18,10 @@ namespace MapsetVerifier.Server.Service;
 public static class BeatmapAnalysisService
 {
     private const double TimelineMarginMs = 2000;
-    private const int MsPerPeak = 1_000;
+
+    // osu!'s own strain section length, so the default grid is 1:1 with the underlying strain data
+    // rather than averaging several sections into one point.
+    private const int MsPerPeak = 400;
     private const int MaxSamplePoints = 1500; // Widen the grid on long maps instead of sending thousands of chart points.
 
     public static BeatmapAnalysisResult Analyze(string beatmapSetFolder)
@@ -407,15 +410,6 @@ public static class BeatmapAnalysisService
         return Math.Max(timingMax, objectsMax);
     }
 
-    private static double GetFirstStrainSectionEndMs(Beatmap beatmap, int msPerPeak)
-    {
-        if (beatmap.HitObjects.Count == 0)
-            return msPerPeak;
-
-        var firstObjectTime = beatmap.HitObjects.Min(hitObject => hitObject.time);
-        return Math.Ceiling(firstObjectTime / msPerPeak) * msPerPeak;
-    }
-
     private static List<DifficultySamplePoint> GetStarRatingSamples(
         Beatmap beatmap,
         List<osu.Game.Rulesets.Difficulty.TimedDifficultyAttributes> timedAttributes,
@@ -541,160 +535,57 @@ public static class BeatmapAnalysisService
             .Skills.Select(skill => new DifficultySkillData
             {
                 SkillName = GetSkillName(skill, beatmap),
-                StrainSamples = GetSkillDifficultySamples(skill, beatmap, pointCount, msPerPeak),
+                StrainSamples = ResampleToGrid(
+                    SkillStrainTimeline.Build(skill, beatmap),
+                    pointCount,
+                    msPerPeak
+                ),
                 DifficultyValue = skill.DifficultyValue(),
             })
-            // Some skills (e.g. osu!std's newer HarmonicSkill-based ones) only expose per-object
-            // difficulty and no hit objects to anchor it to; nothing meaningful to chart there.
+            // A skill with nothing to anchor to (e.g. an empty diff) has no timeline to chart.
             .Where(data => data.StrainSamples.Count > 0)
             .ToList();
     }
 
     /// <summary>
-    ///     Dispatches to the sampling strategy a skill actually supports. Rulesets have been
-    ///     migrating skills off the classic fixed-section <see cref="StrainSkill" /> (e.g. osu!std's
-    ///     Aim now uses <see cref="VariableLengthStrainSkill" />, and Speed/Reading use a
-    ///     HarmonicSkill base with no strain-peaks concept at all) - <see cref="Skill.GetObjectDifficulties" />
-    ///     is the one thing every skill type still exposes, so it's the fallback of last resort.
+    ///     Flattens a skill's difficulty intervals onto the chart's uniform sample grid. Each sample
+    ///     at <c>t</c> is the highest value over <c>[t, t + msPerPeak)</c>, so spikes shorter than the
+    ///     grid still show up (rather than being missed by a point-in-time read) and the "Peak" stat
+    ///     matches the highest point actually drawn. Stretches with no intervals stay at zero, which is
+    ///     what makes breaks read as gaps.
     /// </summary>
-    private static List<DifficultySamplePoint> GetSkillDifficultySamples(
-        Skill skill,
-        Beatmap beatmap,
-        int pointCount,
-        int msPerPeak
-    ) =>
-        skill switch
-        {
-            StrainSkill strainSkill => GetFixedSectionPeakSamples(
-                strainSkill.GetCurrentStrainPeaks().ToList(),
-                beatmap,
-                pointCount,
-                msPerPeak
-            ),
-            VariableLengthStrainSkill variableLengthSkill => GetVariableSectionPeakSamples(
-                variableLengthSkill,
-                beatmap,
-                pointCount,
-                msPerPeak
-            ),
-            _ => GetObjectDifficultySamples(skill, beatmap, pointCount, msPerPeak),
-        };
-
-    private static List<DifficultySamplePoint> GetFixedSectionPeakSamples(
-        List<double> peaks,
-        Beatmap beatmap,
+    private static List<DifficultySamplePoint> ResampleToGrid(
+        List<StrainInterval> intervals,
         int pointCount,
         int msPerPeak
     )
     {
-        var firstSectionEnd = GetFirstStrainSectionEndMs(beatmap, msPerPeak);
-        var samples = new List<DifficultySamplePoint>(pointCount);
-
-        var peakIndex = 0;
-        var currentPeak = 0d;
-
-        for (var index = 0; index < pointCount; index++)
-        {
-            var sampleTime = firstSectionEnd + index * msPerPeak;
-
-            while (peakIndex < peaks.Count && firstSectionEnd + peakIndex * msPerPeak <= sampleTime)
-            {
-                currentPeak = peaks[peakIndex];
-                peakIndex++;
-            }
-
-            samples.Add(new DifficultySamplePoint { TimeMs = sampleTime, Value = currentPeak });
-        }
-
-        return samples;
-    }
-
-    /// <summary>
-    ///     Same idea as <see cref="GetFixedSectionPeakSamples" />, but each peak covers its own
-    ///     <see cref="VariableLengthStrainSkill.StrainPeak.SectionLength" /> instead of a uniform
-    ///     <c>msPerPeak</c>-spaced grid, so section boundaries are accumulated instead of assumed.
-    /// </summary>
-    private static List<DifficultySamplePoint> GetVariableSectionPeakSamples(
-        VariableLengthStrainSkill skill,
-        Beatmap beatmap,
-        int pointCount,
-        int msPerPeak
-    )
-    {
-        if (beatmap.HitObjects.Count == 0)
-            return [];
-
-        var peaks = skill.GetCurrentStrainPeaks().ToList();
-        var sectionStart = beatmap.HitObjects.Min(hitObject => hitObject.time);
-
-        var peakEndTimes = new List<double>(peaks.Count);
-        var cumulative = sectionStart;
-        foreach (var peak in peaks)
-        {
-            cumulative += peak.SectionLength;
-            peakEndTimes.Add(cumulative);
-        }
-
-        var samples = new List<DifficultySamplePoint>(pointCount);
-        var peakIndex = 0;
-        var currentValue = 0d;
-
-        for (var index = 0; index < pointCount; index++)
-        {
-            var sampleTime = index * msPerPeak;
-
-            while (peakIndex < peaks.Count && peakEndTimes[peakIndex] <= sampleTime)
-            {
-                currentValue = peaks[peakIndex].Value;
-                peakIndex++;
-            }
-
-            samples.Add(new DifficultySamplePoint { TimeMs = sampleTime, Value = currentValue });
-        }
-
-        return samples;
-    }
-
-    /// <summary>
-    ///     Fallback for skills with no strain-peaks concept at all: one raw difficulty value per
-    ///     hit object. Difficulty calculators generally need history before they can score an
-    ///     object, so <see cref="Skill.GetObjectDifficulties" /> is usually shorter than the hit
-    ///     object list - align it to the tail of <see cref="Beatmap.HitObjects" /> rather than
-    ///     assuming a fixed skip count, since how many objects get skipped varies per ruleset.
-    ///     Raw per-object values aren't decayed/smoothed like strain peaks, so this reads spikier.
-    /// </summary>
-    private static List<DifficultySamplePoint> GetObjectDifficultySamples(
-        Skill skill,
-        Beatmap beatmap,
-        int pointCount,
-        int msPerPeak
-    )
-    {
-        var difficulties = skill.GetObjectDifficulties();
-        var hitObjects = beatmap.HitObjects;
-        var skipCount = hitObjects.Count - difficulties.Count;
-
-        if (difficulties.Count == 0 || skipCount < 0)
+        if (intervals.Count == 0)
             return [];
 
         var samples = new List<DifficultySamplePoint>(pointCount);
-        var objectIndex = 0;
-        var currentValue = 0d;
+        var intervalIndex = 0;
 
         for (var index = 0; index < pointCount; index++)
         {
-            var sampleTime = index * msPerPeak;
+            var bucketStart = (double)index * msPerPeak;
+            var bucketEnd = bucketStart + msPerPeak;
 
+            // Intervals are chronological and contiguous, so the scan only ever moves forward.
             while (
-                objectIndex < difficulties.Count
-                && hitObjects[skipCount + objectIndex].time <= sampleTime
+                intervalIndex < intervals.Count && intervals[intervalIndex].EndTime <= bucketStart
             )
-            {
-                currentValue = difficulties[objectIndex];
-                objectIndex++;
-            }
+                intervalIndex++;
 
-            samples.Add(new DifficultySamplePoint { TimeMs = sampleTime, Value = currentValue });
+            var value = 0d;
+            for (
+                var scanIndex = intervalIndex;
+                scanIndex < intervals.Count && intervals[scanIndex].StartTime < bucketEnd;
+                scanIndex++
+            )
+                value = Math.Max(value, intervals[scanIndex].Value);
+
+            samples.Add(new DifficultySamplePoint { TimeMs = bucketStart, Value = value });
         }
 
         return samples;

--- a/electron-app/src/components/overview/difficulty/DifficultyOverview.tsx
+++ b/electron-app/src/components/overview/difficulty/DifficultyOverview.tsx
@@ -78,11 +78,8 @@ function DifficultyOverview() {
     groupedDifficulties.find((group) => group.mode === selectedMode) ?? groupedDifficulties[0];
   const selectedDifficulties = selectedGroup?.difficulties ?? EMPTY_DIFFICULTIES;
   const charts = useMemo(
-    () =>
-      buildCharts(selectedDifficulties, data?.msPerPeak, {
-        excludeAimFromCombinedStrain: settings.excludeAimFromCombinedStrain,
-      }),
-    [data?.msPerPeak, selectedDifficulties, settings.excludeAimFromCombinedStrain]
+    () => buildCharts(selectedDifficulties, data?.msPerPeak),
+    [data?.msPerPeak, selectedDifficulties]
   );
 
   const durationMs = charts[0]?.durationMs ?? data?.msPerPeak ?? 0;

--- a/electron-app/src/components/overview/difficulty/difficultyChartModel.ts
+++ b/electron-app/src/components/overview/difficulty/difficultyChartModel.ts
@@ -80,15 +80,9 @@ function toChartPoints(samples: DifficultySamplePoint[]): DifficultyChartDataPoi
   }));
 }
 
-export type BuildChartsOptions = {
-  /** Excludes osu!standard's Aim skill(s) from the combined strain line. */
-  excludeAimFromCombinedStrain?: boolean;
-};
-
 export function buildCharts(
   difficulties: DifficultyOverviewDifficulty[],
-  msPerPeak?: number,
-  options: BuildChartsOptions = {}
+  msPerPeak?: number
 ): ChartDefinition[] {
   if (!msPerPeak || difficulties.length === 0) {
     return [];
@@ -100,7 +94,7 @@ export function buildCharts(
     .filter((series) => series.points.length > 0);
 
   const starRatingStrainSeries = difficulties
-    .map((difficulty) => buildCombinedStrainSeries(difficulty, options))
+    .map((difficulty) => buildCombinedStrainSeries(difficulty))
     .filter((series) => series.points.length > 0);
 
   if (starRatingSeries.length > 0 || starRatingStrainSeries.length > 0) {
@@ -206,12 +200,9 @@ function buildStarRatingSeries(difficulty: DifficultyOverviewDifficulty): Diffic
  * isn't in Star Rating units.
  */
 function buildCombinedStrainSeries(
-  difficulty: DifficultyOverviewDifficulty,
-  options: BuildChartsOptions
+  difficulty: DifficultyOverviewDifficulty
 ): DifficultyChartSeries {
-  const skills = options.excludeAimFromCombinedStrain
-    ? difficulty.skills.filter((skill) => !skill.skillName.startsWith('Aim'))
-    : difficulty.skills;
+  const skills = difficulty.skills;
 
   const bySkillTimeMs = skills[0]?.strainSamples.map((sample) => sample.timeMs) ?? [];
 

--- a/electron-app/src/components/settings/OverviewSettingsSection.tsx
+++ b/electron-app/src/components/settings/OverviewSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { SegmentedControl, Switch } from '@mantine/core';
+import { SegmentedControl } from '@mantine/core';
 import { IconChartAreaLine } from '@tabler/icons-react';
 import { SettingsRow, SettingsSection } from './SettingsSection';
 import { useSettings } from '../../context/SettingsContext';
@@ -33,22 +33,6 @@ export default function OverviewSettingsSection() {
                 difficultyStrainDisplayMode: value as DifficultyStrainDisplayMode,
               }))
             }
-          />
-        }
-      />
-      <SettingsRow
-        title="Exclude Aim from combined strain (osu!standard)"
-        description="Leaves osu!standard's Aim skill(s) out of the combined strain line, since Aim can dominate the line visually even on maps where it barely factors into the real Star Rating."
-        control={
-          <Switch
-            checked={settings.excludeAimFromCombinedStrain}
-            onChange={(e) => {
-              const checked = e.currentTarget.checked;
-              setSettings((prev) => ({
-                ...prev,
-                excludeAimFromCombinedStrain: checked,
-              }));
-            }}
           />
         }
       />

--- a/electron-app/src/context/SettingsContext.tsx
+++ b/electron-app/src/context/SettingsContext.tsx
@@ -23,8 +23,6 @@ export type Settings = {
   showAdvancedAudioAnalysis: boolean;
   /** What the Star Rating overview chart shows by default. */
   difficultyStrainDisplayMode: DifficultyStrainDisplayMode;
-  /** Excludes osu!standard's Aim skill(s) from the combined strain line. */
-  excludeAimFromCombinedStrain: boolean;
   /** Which beatmap library/libraries the sidebar reads from. */
   beatmapViewMode: BeatmapViewMode;
   /** Last selected stable/lazer tab on the beatmaps list. Only used when beatmapViewMode is 'both'. */
@@ -70,7 +68,6 @@ const defaultSettings: Settings = {
   showGamemodeDifficultyNames: true,
   showAdvancedAudioAnalysis: false,
   difficultyStrainDisplayMode: 'strainOnly',
-  excludeAimFromCombinedStrain: true,
   beatmapViewMode: 'stable',
   beatmapLookupMode: 'stable',
   receivePrereleases: false,


### PR DESCRIPTION
Resolve #188

Based on how PerformanceCalculatorGUI shows the strain of a beatmap