### PR TITLE
Adjust osu! standard's drain time in CheckLowestDiff

### DIFF
--- a/MapsetVerifier.Checks/AllModes/Spread/CheckLowestDiff.cs
+++ b/MapsetVerifier.Checks/AllModes/Spread/CheckLowestDiff.cs
@@ -73,6 +73,7 @@ namespace MapsetVerifier.Checks.AllModes.Spread
                 {
                     case Beatmap.Mode.Taiko:
                     case Beatmap.Mode.Catch:
+                    case Beatmap.Mode.Standard:
                         hardThreshold = CreateThreshold(2, 30);
                         insaneThreshold = CreateThreshold(3, 15);
                         expertThreshold = CreateThreshold(4, 0);
@@ -83,12 +84,9 @@ namespace MapsetVerifier.Checks.AllModes.Spread
                         insaneThreshold = CreateThreshold(2, 45);
                         expertThreshold = CreateThreshold(3, 30);
                         break;
-                    case Beatmap.Mode.Standard:
+
                     default:
-                        hardThreshold = CreateThreshold(3, 30);
-                        insaneThreshold = CreateThreshold(4, 15);
-                        expertThreshold = CreateThreshold(5, 0);
-                        break;
+                        throw new ArgumentOutOfRangeException(nameof(mode));
                 }
 
                 var modeBeatmaps = modeBeatmapGroup.ToList();


### PR DESCRIPTION
To be merged after the new drain time rules are in.

I've also changed threshold population to throw explicitly in the default case, since I don't think that's ever supposed to happen