### PR TITLE
Improve offscreen check

### DIFF
--- a/MapsetVerifier.Checks.Tests/Standard/Compose/CheckOffscreenTests.cs
+++ b/MapsetVerifier.Checks.Tests/Standard/Compose/CheckOffscreenTests.cs
@@ -1,0 +1,150 @@
+using MapsetVerifier.Checks.Standard.Compose;
+using MapsetVerifier.Framework.Objects;
+using Xunit;
+
+namespace MapsetVerifier.Checks.Tests.Standard.Compose;
+
+public class CheckOffscreenTests
+{
+    // At CS 5 the circle radius is exactly 32, so with the lower limit at 428 an object is
+    // offscreen from y 397 onwards, and borderline at y 396.
+    private static CheckTestContext CreateContext(params string[] hitObjects) =>
+        CheckTestContext.CreateFromOsu(
+            new OsuBuilder()
+                .Title("Offscreen")
+                .CircleSize(5)
+                .WithDefaultTiming()
+                .HitObjects(hitObjects.ToList())
+        );
+
+    [Fact]
+    public void CircleWellInsideScreen_DoesNotFlag()
+    {
+        using var context = CreateContext(TestHitObjects.Circle(1000, y: 340));
+
+        Assert.Empty(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+    }
+
+    [Fact]
+    public void CircleOffscreenAtBottom_FlagsProblem()
+    {
+        using var context = CreateContext(TestHitObjects.Circle(1000, y: 397));
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Problem, issue.level);
+        Assert.Contains("Circle is offscreen", issue.message);
+    }
+
+    [Fact]
+    public void CircleTouchingBottomEdge_FlagsBorderlineWarning()
+    {
+        using var context = CreateContext(TestHitObjects.Circle(1000, y: 396));
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Warning, issue.level);
+        Assert.Contains("Circle is only 0 px away from being offscreen", issue.message);
+    }
+
+    [Fact]
+    public void CircleJustOutsideBorderlineMargin_DoesNotFlag()
+    {
+        using var context = CreateContext(TestHitObjects.Circle(1000, y: 395));
+
+        Assert.Empty(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+    }
+
+    [Fact]
+    public void CircleHalfAPixelFromEdge_ReportsRemainingMargin()
+    {
+        // Not expressible through integer positions, so the head is placed a pixel higher and
+        // the tail of a linear slider is used to land half a pixel away from the edge instead.
+        using var context = CreateContext(
+            TestHitObjects.Slider(1000, curvePoints: "256:396", length: 95.5, y: 300)
+        );
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Warning, issue.level);
+        Assert.Contains("Slider tail is only 0.5 px away from being offscreen", issue.message);
+    }
+
+    [Fact]
+    public void SliderTailOffscreenAtBottom_FlagsProblem()
+    {
+        using var context = CreateContext(
+            TestHitObjects.Slider(1000, curvePoints: "256:400", length: 100, y: 300)
+        );
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Problem, issue.level);
+        Assert.Contains("Slider tail is offscreen", issue.message);
+    }
+
+    [Fact]
+    public void SliderTailTouchingBottomEdge_FlagsBorderlineWarningOnce()
+    {
+        using var context = CreateContext(
+            TestHitObjects.Slider(1000, curvePoints: "256:396", length: 96, y: 300)
+        );
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Warning, issue.level);
+        Assert.Contains("Slider tail is only 0 px away from being offscreen", issue.message);
+    }
+
+    [Fact]
+    public void SliderTailTouchingRightEdge_FlagsBorderlineWarning()
+    {
+        // The right limit is 579, so with a radius of 32 the body reaches the edge at x 547,
+        // which is outside the playfield and therefore not moved back in by the game.
+        using var context = CreateContext(
+            TestHitObjects.Slider(1000, curvePoints: "547:192", length: 291, x: 256)
+        );
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Warning, issue.level);
+        Assert.Contains("Slider tail is only 0 px away from being offscreen", issue.message);
+    }
+
+    [Fact]
+    public void SliderBodyTouchingBottomEdge_FlagsBorderlineWarning()
+    {
+        // Reverses back to the head, so only the body itself comes close to the edge.
+        using var context = CreateContext(
+            TestHitObjects.Slider(1000, curvePoints: "256:396", slides: 2, length: 96, y: 300)
+        );
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Warning, issue.level);
+        Assert.Contains("Slider body is only 0 px away from being offscreen", issue.message);
+    }
+
+    [Fact]
+    public void BezierSliderWithRedAnchorNearTopEdge_FlagsBorderlineWarning()
+    {
+        // The red anchor at 144:-23 is the topmost point of the path and leaves 0.52 px at CS 4,
+        // which the path sampling used to cut the corner of, reporting several pixels of margin.
+        using var context = CheckTestContext.CreateFromOsu(
+            new OsuBuilder()
+                .Title("Offscreen")
+                .CircleSize(4)
+                .SliderMultiplier(2.4f)
+                .WithDefaultTiming()
+                .HitObjects("150,39,1000,6,0,B|144:-23|144:-23|173:105,1,180,0|0,0:0|0:0,0:0:0:0:")
+        );
+
+        var issue = Assert.Single(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+        Assert.Equal(Issue.Level.Warning, issue.level);
+        // The exact figure follows the sampling, which lands a fraction of a pixel off the anchor.
+        Assert.Contains("Slider body is only 0.", issue.message);
+    }
+
+    [Fact]
+    public void SliderWellInsideScreen_DoesNotFlag()
+    {
+        using var context = CreateContext(
+            TestHitObjects.Slider(1000, curvePoints: "256:340", length: 100, y: 240)
+        );
+
+        Assert.Empty(context.RunBeatmapCheck<CheckOffscreen>("Test"));
+    }
+}

--- a/MapsetVerifier.Checks/Standard/Compose/CheckOffscreen.cs
+++ b/MapsetVerifier.Checks/Standard/Compose/CheckOffscreen.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Globalization;
+using System.Numerics;
 using MapsetVerifier.Framework.Objects;
 using MapsetVerifier.Framework.Objects.Attributes;
 using MapsetVerifier.Framework.Objects.Metadata;
@@ -17,6 +18,11 @@ namespace MapsetVerifier.Checks.Standard.Compose
         private const int LOWER_LIMIT = 428;
         private const int LEFT_LIMIT = -67;
         private const int RIGHT_LIMIT = 579;
+
+        // The limits above are measured rather than exact, and the game additionally rounds positions when
+        // rendering, so an object which is technically onscreen by a fraction of a pixel can still end up
+        // partially offscreen in-game. Those cases are pointed out so they can be checked manually.
+        private const float BorderlineMargin = 1;
 
         public override CheckMetadata GetMetadata() =>
             new BeatmapCheckMetadata
@@ -43,7 +49,9 @@ namespace MapsetVerifier.Checks.Standard.Compose
                         @"
                         Although everything is technically readable and playable if an object is only partially offscreen, it trips up players using relative movement input (for example mouse) when their cursor hits the side of the screen, since the game will offset the cursor back into the screen which is difficult to correct while in the middle of gameplay.
 
-                        Since objects partially offscreen also have a smaller area to hit, if not hitting the screen causing the problems above, it makes those objects need more precision to play which isn't consistent with how the rest of the game works, especially considering that the punishment for overshooting is getting your cursor offset slightly but still hitting the object and not missing like you probably would otherwise."
+                        Since objects partially offscreen also have a smaller area to hit, if not hitting the screen causing the problems above, it makes those objects need more precision to play which isn't consistent with how the rest of the game works, especially considering that the punishment for overshooting is getting your cursor offset slightly but still hitting the object and not missing like you probably would otherwise.
+
+                        The screen limits used here are measured values rather than exact ones, and the game rounds object positions when rendering them, so objects ending up within a pixel of those limits are pointed out as something to verify manually rather than being ignored."
                     },
                 },
             };
@@ -74,6 +82,18 @@ namespace MapsetVerifier.Checks.Standard.Compose
                     )
                 },
                 {
+                    "Borderline",
+                    new IssueTemplate(
+                        Issue.Level.Warning,
+                        "{0} {1} is only {2} px away from being offscreen, ensure the entire white border is visible on a 4:3 aspect ratio.",
+                        "timestamp -",
+                        "object",
+                        "amount"
+                    ).WithCause(
+                        "The border of a hit object is within a pixel of the screen edge in 4:3 aspect ratios, which due to the rounding the game applies can still end up offscreen."
+                    )
+                },
+                {
                     "Bezier Margin",
                     new IssueTemplate(
                         Issue.Level.Warning,
@@ -94,6 +114,7 @@ namespace MapsetVerifier.Checks.Standard.Compose
                 if (hitObject is not Circle && hitObject is not Slider)
                     continue;
 
+                var borderlineReported = false;
                 var circleRadius = beatmap.DifficultySettings.GetCircleRadius();
                 var stackedOffset = new Vector2(0, 0);
 
@@ -147,6 +168,20 @@ namespace MapsetVerifier.Checks.Standard.Compose
                             type
                         );
                 }
+                // Only the bottom is relevant here, as any other edge a head could come close to is one
+                // the game moves it away from anyway.
+                else if (hitObject.Position.Y + circleRadius > LOWER_LIMIT - BorderlineMargin)
+                {
+                    yield return new Issue(
+                        GetTemplate("Borderline"),
+                        beatmap,
+                        Timestamp.Get(hitObject),
+                        type,
+                        FormatMargin(GetOffscreenAmount(hitObject.Position, beatmap))
+                    );
+
+                    borderlineReported = true;
+                }
 
                 if (hitObject is not Slider slider)
                     continue;
@@ -159,62 +194,88 @@ namespace MapsetVerifier.Checks.Standard.Compose
                         Timestamp.Get(hitObject.GetEndTime()),
                         "Slider tail"
                     );
+
+                    continue;
                 }
-                else
+
+                if (IsBorderline(slider.EndPosition, beatmap))
                 {
-                    var offscreenBodyFound = false;
+                    yield return new Issue(
+                        GetTemplate("Borderline"),
+                        beatmap,
+                        Timestamp.Get(hitObject.GetEndTime()),
+                        "Slider tail",
+                        FormatMargin(GetOffscreenAmount(slider.EndPosition, beatmap))
+                    );
 
-                    foreach (var pathPosition in slider.PathPxPositions)
+                    borderlineReported = true;
+                }
+
+                var bodyIssueFound = false;
+
+                foreach (var pathPosition in slider.PathPxPositions)
+                {
+                    if (GetOffscreenBy(pathPosition + stackedOffset, beatmap) <= 0)
+                        continue;
+
+                    yield return new Issue(
+                        GetTemplate("Offscreen"),
+                        beatmap,
+                        Timestamp.Get(hitObject),
+                        "Slider body"
+                    );
+
+                    bodyIssueFound = true;
+
+                    break;
+                }
+
+                if (bodyIssueFound)
+                    continue;
+
+                // Since we sample parts of slider bodies, and these aren't math formulas (although they could be),
+                // we'd need to sample an infinite amount of points on the path, which is too intensive, so instead
+                // we approximate and apply leniency to ensure false-positive over false-negative.
+                var isNearEdge =
+                    slider.CurveType != Slider.Curve.Linear
+                    && slider.PathPxPositions.Any(pathPosition =>
+                        GetOffscreenBy(pathPosition + stackedOffset, beatmap, 2) > 0
+                    );
+
+                if (isNearEdge)
+                {
+                    // The samples above are around a pixel apart, which is too coarse to tell a borderline
+                    // body from a safe one, so the curve is walked in much smaller steps here.
+                    var offscreenAmount = float.NegativeInfinity;
+
+                    for (var j = 0; j < slider.GetCurveDuration() * 50; ++j)
                     {
-                        if (GetOffscreenBy(pathPosition + stackedOffset, beatmap) <= 0)
-                            continue;
+                        var exactPathPosition =
+                            slider.GetPathPosition(slider.time + j / 50d) + stackedOffset;
 
+                        offscreenAmount = Math.Max(
+                            offscreenAmount,
+                            GetOffscreenAmount(exactPathPosition, beatmap)
+                        );
+                    }
+
+                    if (offscreenAmount > 0)
                         yield return new Issue(
                             GetTemplate("Offscreen"),
                             beatmap,
                             Timestamp.Get(hitObject),
                             "Slider body"
                         );
-
-                        offscreenBodyFound = true;
-
-                        break;
-                    }
-
-                    // Since we sample parts of slider bodies, and these aren't math formulas (although they could be),
-                    // we'd need to sample an infinite amount of points on the path, which is too intensive, so instead
-                    // we approximate and apply leniency to ensure false-positive over false-negative.
-                    if (offscreenBodyFound)
-                        continue;
-
-                    foreach (var pathPosition in slider.PathPxPositions)
+                    // The head and tail are part of the body, so a borderline edge there already covers this.
+                    else if (!borderlineReported)
                     {
-                        var exactPathPosition = pathPosition + stackedOffset;
-
-                        if (
-                            GetOffscreenBy(exactPathPosition, beatmap, 2) <= 0
-                            || slider.CurveType == Slider.Curve.Linear
-                        )
-                            continue;
-
-                        var isOffscreen = false;
-
-                        for (var j = 0; j < slider.GetCurveDuration() * 50; ++j)
-                        {
-                            exactPathPosition = slider.GetPathPosition(slider.time + j / 50d);
-
-                            double offscreenBy = GetOffscreenBy(exactPathPosition, beatmap);
-
-                            if (offscreenBy > 0)
-                                isOffscreen = true;
-                        }
-
-                        if (isOffscreen)
+                        if (offscreenAmount > -BorderlineMargin)
                             yield return new Issue(
-                                GetTemplate("Offscreen"),
+                                GetTemplate("Borderline"),
                                 beatmap,
                                 Timestamp.Get(hitObject),
-                                "Slider body"
+                                "Slider body",
+                                FormatMargin(offscreenAmount)
                             );
                         else
                             yield return new Issue(
@@ -222,35 +283,102 @@ namespace MapsetVerifier.Checks.Standard.Compose
                                 beatmap,
                                 Timestamp.Get(hitObject)
                             );
-
-                        break;
                     }
+
+                    continue;
                 }
+
+                if (borderlineReported)
+                    continue;
+
+                var borderlinePosition = GetClosestBorderlinePosition(
+                    slider,
+                    stackedOffset,
+                    beatmap
+                );
+
+                if (borderlinePosition != null)
+                    yield return new Issue(
+                        GetTemplate("Borderline"),
+                        beatmap,
+                        Timestamp.Get(hitObject),
+                        "Slider body",
+                        FormatMargin(GetOffscreenAmount(borderlinePosition.Value, beatmap))
+                    );
             }
+        }
+
+        /// <summary> Returns the sampled path position closest to the screen edge, or null if none are borderline. </summary>
+        private static Vector2? GetClosestBorderlinePosition(
+            Slider slider,
+            Vector2 stackedOffset,
+            Beatmap beatmap
+        )
+        {
+            Vector2? closestPosition = null;
+
+            foreach (var pathPosition in slider.PathPxPositions)
+            {
+                var exactPathPosition = pathPosition + stackedOffset;
+
+                if (!IsBorderline(exactPathPosition, beatmap))
+                    continue;
+
+                if (
+                    closestPosition == null
+                    || GetOffscreenAmount(exactPathPosition, beatmap)
+                        > GetOffscreenAmount(closestPosition.Value, beatmap)
+                )
+                    closestPosition = exactPathPosition;
+            }
+
+            return closestPosition;
+        }
+
+        /// <summary>
+        ///     Returns whether a point is onscreen, but by less than a pixel, in which case the rounding the
+        ///     game applies can still end up pushing it offscreen.
+        /// </summary>
+        private static bool IsBorderline(Vector2 point, Beatmap beatmap) =>
+            GetOffscreenBy(point, beatmap) <= 0
+            && GetOffscreenAmount(point, beatmap) > -BorderlineMargin;
+
+        /// <summary> Returns how many pixels are left before becoming offscreen, as a display string. </summary>
+        private static string FormatMargin(float offscreenAmount)
+        {
+            var margin = Math.Max(-offscreenAmount, 0);
+
+            return (Math.Floor(margin * 100) / 100).ToString("0.##", CultureInfo.InvariantCulture);
         }
 
         /// <summary> Returns how far offscreen an object is in pixels (in-game pixels, not resolution). </summary>
         private static float GetOffscreenBy(Vector2 point, Beatmap beatmap, float leniency = 0)
         {
-            var circleRadius = beatmap.DifficultySettings.GetCircleRadius();
+            var offscreenBy = GetOffscreenAmount(point, beatmap) + leniency;
 
-            float offscreenBy = 0;
-
-            var offscreenRight = point.X + circleRadius - RIGHT_LIMIT + leniency;
-            var offscreenLeft = circleRadius - point.X + LEFT_LIMIT + leniency;
-            var offscreenLower = point.Y + circleRadius - LOWER_LIMIT + leniency;
-            var offscreenUpper = circleRadius - point.Y + UPPER_LIMIT + leniency;
-
-            if (offscreenRight > offscreenBy)
-                offscreenBy = offscreenRight;
-            if (offscreenLeft > offscreenBy)
-                offscreenBy = offscreenLeft;
-            if (offscreenLower > offscreenBy)
-                offscreenBy = offscreenLower;
-            if (offscreenUpper > offscreenBy)
-                offscreenBy = offscreenUpper;
+            if (offscreenBy < 0)
+                offscreenBy = 0;
 
             return (float)Math.Ceiling(offscreenBy * 100) / 100f;
+        }
+
+        /// <summary>
+        ///     Returns how far offscreen a point is in pixels (in-game pixels, not resolution), where negative
+        ///     values represent how far it still is from the screen edge.
+        /// </summary>
+        private static float GetOffscreenAmount(Vector2 point, Beatmap beatmap)
+        {
+            var circleRadius = beatmap.DifficultySettings.GetCircleRadius();
+
+            var offscreenRight = point.X + circleRadius - RIGHT_LIMIT;
+            var offscreenLeft = circleRadius - point.X + LEFT_LIMIT;
+            var offscreenLower = point.Y + circleRadius - LOWER_LIMIT;
+            var offscreenUpper = circleRadius - point.Y + UPPER_LIMIT;
+
+            return Math.Max(
+                Math.Max(offscreenRight, offscreenLeft),
+                Math.Max(offscreenLower, offscreenUpper)
+            );
         }
     }
 }

--- a/MapsetVerifier.Parser.Tests/Objects/HitObjects/SliderPathTests.cs
+++ b/MapsetVerifier.Parser.Tests/Objects/HitObjects/SliderPathTests.cs
@@ -1,0 +1,109 @@
+using System.Numerics;
+using MapsetVerifier.Parser.Objects;
+using MapsetVerifier.Parser.Objects.HitObjects;
+using Xunit;
+
+namespace MapsetVerifier.Parser.Tests.Objects.HitObjects;
+
+public class SliderPathTests
+{
+    private static Slider CreateSlider(string hitObject)
+    {
+        var code = $"""
+[General]
+Mode: 0
+
+[Metadata]
+Version:Test
+
+[Difficulty]
+CircleSize:4
+HPDrainRate:5
+OverallDifficulty:5
+ApproachRate:5
+SliderMultiplier:2.4
+SliderTickRate:1
+
+[TimingPoints]
+0,333.333333333333,4,2,0,100,1,0
+
+[HitObjects]
+{hitObject}
+""";
+
+        return (Slider)new Beatmap(code, "song", "map.osu").HitObjects.First();
+    }
+
+    [Fact]
+    public void RedAnchor_IsReachedBySampledPath()
+    {
+        // Two linear segments joined by a red anchor at 144:-23, which is the sharpest and most
+        // extreme point of the path. Sampling at fixed intervals cuts such corners, so the anchor
+        // has to be part of the curve the path is sampled from.
+        var slider = CreateSlider(
+            "150,39,57338,6,0,B|144:-23|144:-23|173:105,1,180,0|0,0:0|0:0,0:0:0:0:"
+        );
+
+        var closest = slider.PathPxPositions.Min(position =>
+            Vector2.Distance(position, new Vector2(144, -23))
+        );
+
+        Assert.True(
+            closest < 1,
+            $"Closest sampled position to the red anchor was {closest} px off."
+        );
+    }
+
+    [Fact]
+    public void RedAnchorBeyondPixelLength_IsNotReachedBySampledPath()
+    {
+        // The slider is cut short well before the anchor at 144:-23, so the path never reaches it.
+        var slider = CreateSlider(
+            "150,39,57338,6,0,B|144:-23|144:-23|173:105,1,20,0|0,0:0|0:0,0:0:0:0:"
+        );
+
+        var closest = slider.PathPxPositions.Min(position =>
+            Vector2.Distance(position, new Vector2(144, -23))
+        );
+
+        Assert.True(
+            closest > 40,
+            $"Closest sampled position to the red anchor was {closest} px off."
+        );
+    }
+
+    [Fact]
+    public void PathAroundRedAnchors_HasNoCoincidentPoints()
+    {
+        // Anything reading the angles between path points needs the points to be spread out, so
+        // including anchors may not leave two points nearly on top of each other.
+        var slider = CreateSlider(
+            "256,100,57338,6,0,B|200:100|200:100|150:150|150:150|250:200|250:200|300:100,1,300,0|0,0:0|0:0,0:0:0:0:"
+        );
+
+        var positions = slider.PathPxPositions;
+
+        // The last position is the end of the curve, which is appended regardless of how close it is.
+        for (var i = 1; i < positions.Count - 1; ++i)
+        {
+            var gap = Vector2.Distance(positions[i - 1], positions[i]);
+
+            Assert.True(gap > 0.2, $"Positions {i - 1} and {i} are only {gap} px apart.");
+        }
+    }
+
+    [Fact]
+    public void SampledPath_StaysWithinPixelLength()
+    {
+        var slider = CreateSlider(
+            "150,39,57338,6,0,B|144:-23|144:-23|173:105,1,180,0|0,0:0|0:0,0:0:0:0:"
+        );
+
+        double length = 0;
+        for (var i = 1; i < slider.PathPxPositions.Count; ++i)
+            length += Vector2.Distance(slider.PathPxPositions[i - 1], slider.PathPxPositions[i]);
+
+        // The path is sampled, so it is a little shorter than the curve it approximates, never longer.
+        Assert.InRange(length, 170, 181);
+    }
+}

--- a/MapsetVerifier.Parser/Objects/HitObjects/Slider.cs
+++ b/MapsetVerifier.Parser/Objects/HitObjects/Slider.cs
@@ -719,6 +719,7 @@ namespace MapsetVerifier.Parser.Objects.HitObjects
                 // Calculate how long this curve (not the whole thing, just from anchor to anchor) will be.
                 var prevPoint = points.First();
                 double curvePixelLength = 0;
+                var sampledThisSegment = false;
 
                 for (double k = 0.0f; k < 1.0f + STEP_LENGTH; k += STEP_LENGTH)
                     if (totalLength <= fullLength)
@@ -732,15 +733,28 @@ namespace MapsetVerifier.Parser.Objects.HitObjects
                             totalLength += curvePixelLength;
                             curvePixelLength = 0;
                             tempBezierPoints.Add(currentPoint);
+                            sampledThisSegment = true;
                         }
                     }
 
                 // As long as we haven't reached the last path between anchors, keep track of the length of the path.
                 // Ensures that we can switch from one anchor path to another.
-                if (tteration <= sliderPoints.Count)
-                    totalLength += curvePixelLength;
-                else
-                    tempBezierPoints.Add(currentPoint);
+                totalLength += curvePixelLength;
+
+                if (totalLength > fullLength)
+                    continue;
+
+                // The last control point of a segment lies on the curve itself, and for sharp anchors it is
+                // often the most extreme point of the whole path, which the sampling above cuts the corner of
+                // since it only adds points at fixed intervals. Move the last sample of the segment onto the
+                // anchor rather than adding a point next to it, as points nearly on top of each other make
+                // the path useless to anything looking at the angles between its points.
+                var anchorPoint = points.Last();
+
+                if (sampledThisSegment)
+                    tempBezierPoints[^1] = anchorPoint;
+                else if (GetDistance(tempBezierPoints.Last(), anchorPoint) >= pixelsPerMs)
+                    tempBezierPoints.Add(anchorPoint);
             }
 
             return tempBezierPoints;


### PR DESCRIPTION
Based on no missed ones found in https://osu.ppy.sh/beatmapsets/2521355/discussion/5566010/general/total#/5661956

Now points out 00:57:338 (1) and 01:06:611 (1) on top diff