### PR TITLE
Fix typo: Portugese → Portuguese in language tags

### DIFF
--- a/MapsetVerifier.Checks/AllModes/General/Metadata/CheckGenreLanguage.cs
+++ b/MapsetVerifier.Checks/AllModes/General/Metadata/CheckGenreLanguage.cs
@@ -43,7 +43,7 @@ namespace MapsetVerifier.Checks.AllModes.General.Metadata
             ["Conlang"],
             ["Hindi"],
             ["Arabic"],
-            ["Portugese"],
+            ["Portuguese"],
             ["Turkish"],
             ["Vietnamese"],
             ["Persian"],


### PR DESCRIPTION
Fixes #219 — the `Portugese` typo in `LanguageTagCombinations` should be `Portuguese`. This was causing a false positive warning for Portuguese language tags.